### PR TITLE
Making Security objectives use links to threat definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1443,52 +1443,52 @@
 
 
 <tr>
-<td><strong>WoT Protocol Bindings</strong></td>
+<td><a>WoT Protocol Binding Threat</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT devices sends a malformed request to a WoT device using directly Protocol Bindings interface. This malformed request causes the respective Protocol Binding to be compromised and attacker is able to run the code with the privileges of the Protocol Binding on the WoT device.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT Interface - General Compromise</strong></td>
+<td><a>WoT Interface Threat - General Compromise</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT devices sends a malformed request to a WoT device using WoT interface. This malformed request causes the respective Thing Instance to be compromised and attacker is able to run the code with the privileges of the Thing Instance on the WoT device.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT Interface - Unauthorized WoT Interface access</strong></td>
+<td><a>WoT Interface Threat - Unauthorized WoT Interface Access</a></td>
 <td>A user's party guest with the network access to the same internal network as WoT devices using his device sends a WoT interface request to a user's WoT device for a certain resource access, for example, to get a video stream from user's video camera footage or permission to unlock some rooms in the house. Due to lack of proper authentication, it is able to access this information or execute the required action (opening the door).</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT communication - TD Authenticity</strong></td>
+<td><a>WoT Communication Threat - TD Authenticity</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT devices listens to the network and intercepts a legitimate TD send by one of the WoT devices. Then it modifies the TD to state different authentication method or authority and forwards it to the intended device. The device follow the instructions in the modified TD and sends authentication request to the attacker's specified location potentially revealing its credentials, such as keys etc. Similarly instead of modifying the legitimate TD, an attack might save it and use later on, for example when it would be updated to a newer version. Then, an attacker substitutes a new version of TD with an older version to cause DoS to a device trying to get an access to a resource. An additional reason for using an older TD might be exposing a previously available vulnerable interface that got hidden when TD was updated to a newer version. This can be a stepping stone to conducting other attacks on the WoT network.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT communication - TD Confidentiality</strong></td>
+<td><a>WoT Communication Threat - TD Confidentiality</a></td>
 <td>A user's party guest with the network access to the same internal network as WoT devices using his device listens to the network and intercepts a legitimate TD send by one of the WoT devices. While inspecting the TD he/she learns the privacy-sensitive information about the host, such as presence of medical tracking/assistant equipment, name of healthcare provider company etc.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT communication - Solution Data Authenticity</strong></td>
+<td><a>WoT Communication Threat - Solution Data Authenticity</a></td>
 <td>A user's party guest with the network access to the same internal network as WoT devices using his device listens to the network and intercepts a legitimate WoT interface request to set some settings on some actuator, for example the time when house doors get locked and unlocked. He then modifies the specified value to the desirable one and then forwards the request to the destination WoT device. The destination WoT device accepts incorrect settings.<br />Another attack example is a replay of a legitimate WoT interface request to set a setting, for example, increase temperature of the house by a number of degrees. When repeated many times, it might not only make living environment unusable, but also break heating equipment.<br />Another attack involves replaying an old legitimate WoT interface request that attacker intercepts while visiting user's home, such as command to unlock the doors, stop camera recordings etc. in a different time when user wants to get authorized access to the house.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT communication - Solution Data Confidentiality</strong></td>
+<td><a>WoT Communication Threat - Solution Data Confidentiality</a></td>
 <td>A user's party guest with the network access to the same internal network as WoT devices using his device listens to the network and intercepts WoT interface exchange between legitimate entities. From that exchange the guest learns the privacy-sensitive information about the host, such as data stream from his medical tracking equipment, information about user's preferences in home environment, video/audio camera stream etc.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT DoS</strong></td>
+<td><a>WoT DoS Threat</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT devices sends huge amount of requests to either a single WoT device or all device available in the WoT network using directly Protocol Bindings interface or WoT interface. These requests fully take the processing bandwidth of a WoT device or WoT network and make it impossible for legitimate users to communicate with WoT devices or devices to communicate with each other. Depending on the implementation it can also lead to the case that alarm or authentication systems might be disabled and thieves get into user's house (however systems should always implement "safe defaults" principle and in such cases keeps doors closed despite of inability to authenticate).</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT TD Privacy</strong></td>
+<td><a>WoT TD Privacy Threat</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT devices listens for publicly broadcasted TDs and sends this data to a remote attacker to build a profile of home installed devices and their purpose.</td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT TD - Local Storage</strong></td>
+<td><a>WoT TD Threat - Local Storage</a></td>
 <td></td>
 <td>TBD</td>
 </tr>
@@ -1506,15 +1506,15 @@
 
 
 <tr>
-<td><strong>Non-WoT End Point</strong></td>
+<td><a>Non-WoT End Point Threat</a></td>
 <td><strong>Reasoning</strong> : The security of non-WoT end points and their external interfaces is out of the WoT scope. <strong>Recommendations</strong> : Solution providers and OEMs are recommended to use industry best security practices when designing their non-WoT End points, protocols and interfaces.</td>
 </tr>
 <tr>
-<td><strong>WoT Platform</strong></td>
+<td><a>WoT Platform Threat</a></td>
 <td>TBD</td>
 </tr>
 <tr>
-<td><strong>WoT communication Side Channels</strong></td>
+<td><a>WoT Communication Threat - Side Channels</a></td>
 <td>TBD</td>
 </tr>
 <tr>
@@ -1543,52 +1543,52 @@
     </tr>
 
     <tr>
-    <td><strong>WoT Protocol Bindings</strong></td>
+    <td><a>WoT Protocol Binding Threat</a></td>
     <td> </td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT Interface - General Compromise</strong></td>
+    <td><a>WoT Interface Threat - General Compromise</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT Interface - Unauthorized WoT Interface access</strong></td>
+    <td><a>WoT Interface Threat - Unauthorized WoT Interface Access</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - TD Authenticity</strong></td>
+    <td><a>WoT Communication Threat - TD Authenticity</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - TD Confidentiality</strong></td>
+    <td><a>WoT Communication Threat - TD Confidentiality</a></td>
     <td> </td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - Solution Data Authenticity</strong></td>
+    <td><a>WoT Communication Threat - Solution Data Authenticity</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - Solution Data Confidentiality</strong></td>
+    <td><a>WoT Communication Threat - Solution Data Confidentiality</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT DoS</strong></td>
-    <td>A</td>
-    <td>TBD</td>
-    </tr>
-    <tr>
-    <td><strong>WoT TD Privacy</strong></td>
+    <td><a>WoT DoS Threat</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT TD - Local Storage</strong></td>
+    <td><a>WoT TD Privacy Threat</a></td>
+    <td></td>
+    <td>TBD</td>
+    </tr>
+    <tr>
+    <td><a>WoT TD Threat - Local Storage</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
@@ -1602,15 +1602,15 @@
     <th><strong>Reasoning &amp; recommendation</strong></th>
     </tr>
     <tr>
-    <td><strong>Non-WoT End Point</strong></td>
-    <td><strong></td>
-    </tr>
-    <tr>
-    <td><strong>WoT Platform</strong></td>
+    <td><a>Non-WoT End Point Threat</a></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication Side Channels</strong></td>
+    <td><a>WoT Platform Threat</a></td>
+    <td>TBD</td>
+    </tr>
+    <tr>
+    <td><a>WoT Communication Threat - Side Channels</a></td>
     <td>TBD</td>
     </tr>
     <tr>
@@ -1639,52 +1639,52 @@
     </tr>
 
     <tr>
-    <td><strong>WoT Protocol Bindings</strong></td>
+    <td><a>WoT Protocol Binding Threat</a></td>
     <td> </td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT Interface - General Compromise</strong></td>
+    <td><a>WoT Interface Threat - General Compromise</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT Interface - Unauthorized WoT Interface access</strong></td>
+    <td><a>WoT Interface Threat - Unauthorized WoT Interface Access</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - TD Authenticity</strong></td>
+    <td><a>WoT Communication Threat - TD Authenticity</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - TD Confidentiality</strong></td>
+    <td><a>WoT Communication Threat - TD Confidentiality</a></td>
     <td> </td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - Solution Data Authenticity</strong></td>
+    <td><a>WoT Communication Threat - Solution Data Authenticity</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication - Solution Data Confidentiality</strong></td>
+    <td><a>WoT Communication Threat - Solution Data Confidentiality</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT DoS</strong></td>
-    <td>A</td>
-    <td>TBD</td>
-    </tr>
-    <tr>
-    <td><strong>WoT TD Privacy</strong></td>
+    <td><a>WoT DoS Threat</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT TD - Local Storage</strong></td>
+    <td><a>WoT TD Privacy Threat</a></td>
+    <td></td>
+    <td>TBD</td>
+    </tr>
+    <tr>
+    <td><a>WoT TD Threat - Local Storage</a></td>
     <td></td>
     <td>TBD</td>
     </tr>
@@ -1698,15 +1698,15 @@
     <th><strong>Reasoning &amp; recommendation</strong></th>
     </tr>
     <tr>
-    <td><strong>Non-WoT End Point</strong></td>
-    <td><strong></td>
-    </tr>
-    <tr>
-    <td><strong>WoT Platform</strong></td>
+    <td><a>Non-WoT End Point Threat</a></td>
     <td>TBD</td>
     </tr>
     <tr>
-    <td><strong>WoT communication Side Channels</strong></td>
+    <td><a>WoT Platform Threat</a></td>
+    <td>TBD</td>
+    </tr>
+    <tr>
+    <td><a>WoT Communication Threat - Side Channels</a></td>
     <td>TBD</td>
     </tr>
     <tr>
@@ -1719,10 +1719,9 @@
    </section>
    <section id="determine-suitable-architecture">
    <h2>Determining a suitable security architecture</h2>
-            <p> 
-              <!-- todo: List the criteria that raise risk level for particular WoT architecture, such as handing privacy-sensitive data, physical safety, etc. (we started to build this list, need to finish)  --> 
-              <!-- todo: Talk about capabilities of devices themselves, what security protocols are supported, how processes isolation is implemented (granularity: everything runs as one process, only kernel - vs. userspace isolation, process isolation, script isolation etc.), etc.   -->
-              <!-- todo: List additional factors that are important in selecting security architecture   -->
+            <p class="ednote" title="Fill in the content">
+            This subsection content needs to be added.
+            Here we will list the criteria that raise risk level for particular WoT architecture, such as handing privacy-sensitive data, physical safety, etc. Also talk about capabilities of devices themselves, what security protocols are supported, how processes isolation is implemented (granularity: everything runs as one process, only kernel - vs. userspace isolation, process isolation, script isolation etc.), etc. Need also to list additional factors that are important in selecting security architecture.
             </p>
     </section>
 


### PR DESCRIPTION
This is a pure formatting fix to use links to thread model definitions as well as bring the todo note on section 2.4 visible as editor note 