### PR TITLE
Remove redundant security objectives content

### DIFF
--- a/wot-security-scenarios-objectives.md
+++ b/wot-security-scenarios-objectives.md
@@ -1,33 +1,5 @@
-## WoT Security Scenarious and Objectives
+## WoT Security Scenarios and Objectives
 
-**Security objectives**
-
-**Scenario 1 - Home environment**
-
-In this scenario we assume a standard home environment with a WoT network running behind a firewall that separates it from the rest of the Internet. However the WoT network is shared with the standard user home network that contains other non-WoT devices that have high chances of being compromised. This results on viewing these non-WoT devices as network attackers with access to WoT network and its APIs/Protocol Bindings. WoT scripts and protocol bindings are considered trusted, single solution provider exists on physical WoT devices, no dynamic installation of WoT scripts are possible.
-
-This scenario implies the following **WoT Security objectives**:
-
-| **Threat name** | **Example(s)** | **Mitigation** |
-| --- | --- | --- |
-| **WoT Protocol Bindings** | A compromised application on a user smartphone connected to the same internal network as WoT devices sends a malformed request to a WoT device using directly Protocol Bindings interface. This malformed request causes the respective Protocol Binding to be compromised and attacker is able to run the code with the privileges of the Protocol Binding on the WoT device.  | TBD |
-| **WoT Interface - General Compromise** | A compromised application on a user smartphone connected to the same internal network as WoT devices sends a malformed request to a WoT device using WoT interface. This malformed request causes the respective Thing Instance to be compromised and attacker is able to run the code with the privileges of the Thing Instance on the WoT device.| TBD  |
-| **WoT Interface - Unauthorized API access** | A user's party guest with the network access to the same internal network as WoT devices using his device sends a WoT interface request to a user's WoT device for a certain resource access, for example, to get a video stream from user's video camera footage or permission to unlock some rooms in the house. Due to lack of proper authentication, it is able to access this information or execute the required action (opening the door). | TBD  |
-| **WoT communication - TD Authenticity** | A compromised application on a user smartphone connected to the same internal network as WoT devices listens to the network and intercepts a legitimate TD send by one of the WoT devices. Then it modifies the TD to state different authentication method or authority and forwards it to the intended device. The device follow the instructions in the modified TD and sends authentication request to the attacker's specified location potentially revealing its credentials, such as keys etc. Similarly instead of modifying the legitimate TD, an attack might save it and use later on, for example when it would be updated to a newer version. Then, an attacker substitutes a new version of TD with an older version to cause DoS to a device trying to get an access to a resource. An additional reason for using an older TD might be exposing a previously available vulnerable interface that got hidden when TD was updated to a newer version. This can be a stepping stone to conducting other attacks on the WoT network.| TBD |
-| **WoT communication - TD Confidentiality** | A user's party guest with the network access to the same internal network as WoT devices using his device listens to the network and intercepts a legitimate TD send by one of the WoT devices. While inspecting the TD he/she learns the privacy-sensitive information about the host, such as presence of medical tracking/assistant equipment, name of healthcare provider company etc. | TBD  |
-| **WoT communication - Solution Data Authenticity** | A user's party guest with the network access to the same internal network as WoT devices using his device listens to the network and intercepts a legitimate WoT interface request to set some settings on some actuator, for example the time when house doors get locked and unlocked. He then modifies the specified value to the desirable one and then forwards the request to the destination WoT device. The destination WoT device accepts incorrect settings.<br />Another attack example is a replay of a legitimate WoT interface request to set a setting, for example, increase temperature of the house by a number of degrees. When repeated many times, it might not only make living environment unusable, but also break heating equipment.<br />Another attack involves replaying an old legitimate WoT interface request that attacker intercepts while visiting user's home, such as command to unlock the doors, stop camera recordings etc. in a different time when user wants to get authorized access to the house.  |  TBD  |
-| **WoT communication - Solution Data Confidentiality**  |  A user's party guest with the network access to the same internal network as WoT devices using his device listens to the network and intercepts WoT interface exchange between legitimate entities. From that exchange the guest learns the privacy-sensitive information about the host, such as data stream from his medical tracking equipment, information about user's preferences in home environment, video/audio camera stream etc. |  TBD  |
-| **WoT DoS** | A compromised application on a user smartphone connected to the same internal network as WoT devices sends huge amount of requests to either a single WoT device or all device available in the WoT network using directly Protocol Bindings interface or WoT interface. These requests fully take the processing bandwidth of a WoT device or WoT network and make it impossible for legitimate users to communicate with WoT devices or devices to communicate with each other. Depending on the implementation it can also lead to the case that alarm or authentication systems might be disabled and thieves get into user's house (however systems should always implement "safe defaults" principle and in such cases keeps doors closed despite of inability to authenticate). | TBD |
-| **WoT TD Privacy** | A compromised application on a user smartphone connected to the same internal network as WoT devices listens for publicly broadcasted TDs and sends this data to a remote attacker to build a profile of home installed devices and their purpose. | TBD |
-| **WoT TD - Local Storage** | | TBD |
-
-
-As well as the following **Security non-objectives**:
-
-| **Threat name** | **Reasoning &amp; recommendation** |
-| --- | --- |
-| **Non-WoT End Point** | **Reasoning** : The security of non-WoT end points and their external interfaces is out of the WoT scope. **Recommendations** : Solution providers and OEMs are recommended to use industry best security practices when designing their non-WoT End points, protocols and interfaces.|
-| **WoT Platform**| TBD |
-| **WoT communication Side Channels** |  TBD |
-|   |   |
+The WoT security scenarios and objectives material has been moved to the 
+[WoT Security and Privacy Considerations](index.html#wot-security-objectives) document.
 


### PR DESCRIPTION
Removed redundant security objectives information from the md file of the same name.   I left the file alone but the content has been replaced with a link into the index.html file.