### PR TITLE
add w3cid to Elena and McCool

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,13 +21,13 @@
             , editors: [
                 {
                   name:       "Elena Reshetova"
-                , w3cid:      "xxxxx"
+                , w3cid:      "99327"
                 , company:    "Intel Corp."
                 , companyURL: "https://www.intel.com/"
                 },
                 {
                   name:       "Michael McCool"
-                , w3cid:      "xxxxx"
+                , w3cid:      "93137"
                 , company:    "Intel Corp."
                 , companyURL: "https://www.intel.com/"
                 }


### PR DESCRIPTION
We need to specify w3cid parameter for the Editors for the publication, so I've added w3cid's to Elena and McCool.