### PR TITLE
Security metadata strawman

### DIFF
--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -51,12 +51,26 @@ HTTP authentication for HTTP links and ACL for equivalent CoAP links:
             {
               "href": "coaps://mylamp.example.com:5683/status",
               "mediaType": "application/json",
+              "method": "coap:get",
               "security": "ocf-config"
+            },
+            {
+              "href": "coaps://mylamp.example.com:5683/status",
+              "mediaType": "application/json",
+              "method": "coap:post",
+              "security": ["ocf-config","apikey-config"]
             },
             {
               "href": "https://mylamp.example.com/status",
               "mediaType": "application/json",
+              "method": "http:get",
               "security": "basic-config"
+            },
+            {
+              "href": "https://mylamp.example.com/status",
+              "mediaType": "application/json",
+              "method": "http:post",
+              "security": ["basic-config","apikey-config"]
             },
           ]
         },
@@ -107,14 +121,22 @@ as is often necessary when multiple protocols are supported for the same interac
 since different protocols may support different security mechanisms.  In this case we
 also wanted to support stronger security for actions that change the state of the light.
 
-TODO: We may want "read" access (eg the "GET" method) on a property to have different
-(for example, weaker) security than "write" access (eg the "POST" and "PUT" methods).
-How would we specify that here?
+Since the API also allows changing the state of the light by writing to the "status" property,
+we specify that "read" access (eg the "GET" method) on this property to has different
+(weaker) security than "write" access (eg the "POST" and "PUT" methods).
+In this example reads just require basic HTTP authentication
+(or, under OCF, appropriate ACL authorization) but writes in addition require an API key,
+consistent with the actions.  Note that in
+practice the API key may not be needed to provide this differential access under OCF as the ACL
+can include differential read/write access for different users (although that access is tied to 
+identity, not ownership of the API key, so the additional API key provides an additional 
+layer of security; in particular, an API key can be updated on a device to revoke access to
+everyone with the old key).
 
 The value in a security object inside a form can be a single string or an object.
 If a string, it is an identifier that refers to a previously declared configuration at the 
 top level.  If an object, it is a local configuration definition.  If an array, then
-a set of configurations may be given, all of which must be satisfied to allow access.
+a set of configurations may be given, _all_ of which must be satisfied to allow access.
 Arrays can contain strings or objects, or both.
 
 ## Additional Examples:

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -312,3 +312,7 @@ and perhaps the amount per use.  Units also need to be specified.   This will of
 combined with other forms of authentication.  While not strictly a security mechanism,
 it may be used as such (although maybe it's something only used indirectly eg at a
 "ticket vending" service, not at individual IoT devices).
+
+## References
+
+TO DO.

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -204,7 +204,7 @@ Each configuration is identified with a "type" which must be one of the followin
 - "ocf": OCF security model (ACL)
 - "apikey": API key
 - "bearer": bearer token (to discuss: stand-alone possible?)
-- "jwt": Javascript Web Token (to discuss: also under HTTP, but... what about CoAP, etc?)
+- "jwt": JSON Web Token (to discuss: also under HTTP, but... what about CoAP, etc?)
 - "oauth2": OAuth2.0 (requires a flow definition)
 - "openIdConnect": OpenID Connect
 For each type, additional parameters may or may not be required.
@@ -220,7 +220,7 @@ using the additional parameter "scheme" with the following values [RFC7235 https
 - "bearer": bearer token
 If a bearer token is used, its format must be specified using "format", which should
 have one of the following values.
-- "jwt": Javascript Web Token
+- "jwt": JSON Web Token
 
 ### HTTP Proxy Authentication
 
@@ -332,4 +332,7 @@ as it is not yet fully standards-track (although it is on its way).
 
 ## References
 
-TO DO.
+- [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md)
+- [RFC7617 - The 'Basic' HTTP Authentication Scheme](https://tools.ietf.org/html/rfc7617)
+- [RFC7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
+- [RFC7235 Hypertext Transfer Protocol (HTTP/1.1): Authentication](https://tools.ietf.org/html/rfc7235)

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -341,3 +341,4 @@ as it is not yet fully standards-track (although it is on its way).
 - [RFC8152 CBOR Object Signing and Encryption (COSE)](https://tools.ietf.org/html/rfc8152)
 - [Authentication and Authorization for Constrained Environments (ACE); _Internet Draft_](https://tools.ietf.org/html/draft-ietf-ace-oauth-authz-09)
 - [OCF Specifications](https://openconnectivity.org/developer/specifications)
+- [AWS IoT Security Documentation](https://docs.aws.amazon.com/iot/latest/developerguide/iot-security-identity.html)

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -30,8 +30,8 @@ HTTP authentication for HTTP links and ACL for equivalent CoAP links:
           "scheme": "basic"
         },
         {
-          "id": "acl",
-          "type": "ocf",
+          "id": "ocfACL",
+          "type": "ocf"
         },
         {
           "id": "key",
@@ -50,7 +50,7 @@ HTTP authentication for HTTP links and ACL for equivalent CoAP links:
             {
               "href": "coaps://mylamp.example.com:5683/status",
               "mediaType": "application/json",
-              "security": "acl"
+              "security": "ocfACL"
             },
             {
               "href": "https://mylamp.example.com/status",
@@ -66,7 +66,7 @@ HTTP authentication for HTTP links and ACL for equivalent CoAP links:
             {
               "href": "coaps://mylamp.example.com:5683/toggle",
               "mediaType": "application/json"
-              "security": ["acl","key"]
+              "security": ["ocfACL","key"]
             },
             {
               "href": "https://mylamp.example.com/toggle",
@@ -83,7 +83,7 @@ HTTP authentication for HTTP links and ACL for equivalent CoAP links:
             {
               "href": "coaps://mylamp.example.com:5683/oh",
               "mediaType": "application/json"
-              "security": "acl"
+              "security": "ocfACL"
             },
             {
               "href": "https://mylamp.example.com/oh",
@@ -103,7 +103,12 @@ basic authentication and the key).
 
 Note that security is specified per "form" so that it can be different for each one,
 as is often necessary when multiple protocols are supported for the same interaction,
-since different protocols may support different security mechanisms.
+since different protocols may support different security mechanisms.  In this case we
+also wanted to support stronger security for actions that change the state of the light.
+
+TODO: We may want "read" access (eg the "GET" method) on a property to have different
+(for example, weaker) security than "write" access (eg the "POST" and "PUT" methods).
+How would we specify that here?
 
 The value in a security object inside a form can be a single string or an object.
 If a string, it is an identifier that refers to a previously declared configuration at the 
@@ -112,6 +117,89 @@ a set of configurations may be given, all of which must be satisfied to allow ac
 Arrays can contain strings or objects, or both.
 
 ## Detailed Specifications of Configuration Specifications
-To Do.
 
--
+Each configuration is identified with a "type" which must be one of the following:
+- "http": HTTP Authentication
+- "ocf": OCF security model (ACL)
+- "apiKey": API key
+- "oauth2": OAuth2.0
+- "openIdConnect": OpenID Connect
+For each type, additional parameters may or may not be required.
+These are specified in the corresponding sections below. 
+
+### Basic HTTP Authentication
+
+Type: "http"
+
+The standard HTTP security models can be specified (obviously, just on HTTP links) by
+using the additional parameter "scheme" with the following values [RFC7235 https://tools.ietf.org/html/rfc7235#section-5.1]
+- "basic": simple authentication
+- "bearer": bearer token
+If a bearer token is used, its format must be specified using "format", which should
+have one of the following values.
+- "JWT": Javascript Web Token
+
+### OCF Security Model
+
+Type: "ocf"
+
+OCF mandates a specific security model, including ACLs (access control lists).
+As OCF itself defines a set of standard introspection mechanisms to discover
+security metadata, rather than repeat it all we simply specify that the OCF model
+is used.
+
+### API Key
+ 
+Type: "apiKey"
+
+OpenAPI-like API key specifications.  The key can be given in either the header or in the 
+body, as indicated by the value of the "in" field:
+- "in":"header" - the key is in the header
+- "in":"body" - the key is in the body 
+- "in":"cookie" - the key is in a cookie 
+
+### OAuth2.0
+
+Type: "oauth2"
+
+To do. There are also multiple flows: implicit, password, clientCredentials, and authorizationCode.
+
+### OpenID Connect
+
+Type: "openIdConnect"
+
+To do.
+
+### Interledger
+ 
+Type: "interledger"
+
+To do.
+
+## Issues
+The following need to be discussed.
+
+### Authentication Server Link
+Many of these schemes require use of an authentication server.
+Should the metadata include a link to the authentication server in this case?
+
+### Bearer Token Format
+OpenAPI does not specify the terms used to identify different kinds of bearer tokens, since
+they are not created by the client, but by an authentication server.
+Should we be stricter, or not?
+
+### Cookie API Keys
+Does this even make sense for M2M IoT APIs?
+
+### OAuth
+What about other versions of OAuth? What about versions in general?
+
+### OpenIDConnect
+Does this even make sense for IoT devices?
+
+### Interledger
+In addition to the address, it is necessary to specify the amount of deposit required,
+and perhaps the amount per use.  Units also need to be specified.   This will often be
+combined with other forms of authentication.  While not strictly a security mechanism,
+it may be used as such (although maybe it's something only used indirectly eg at a
+"ticket vending" service, not at individual IoT devices).

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -336,3 +336,8 @@ as it is not yet fully standards-track (although it is on its way).
 - [RFC7617 - The 'Basic' HTTP Authentication Scheme](https://tools.ietf.org/html/rfc7617)
 - [RFC7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
 - [RFC7235 Hypertext Transfer Protocol (HTTP/1.1): Authentication](https://tools.ietf.org/html/rfc7235)
+- [RFC6749 The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
+- [RFC7252 The Constrained Application Protocol (CoAP)](https://tools.ietf.org/html/rfc7252)
+- [RFC8152 CBOR Object Signing and Encryption (COSE)](https://tools.ietf.org/html/rfc8152)
+- [Authentication and Authorization for Constrained Environments (ACE); _Internet Draft_](https://tools.ietf.org/html/draft-ietf-ace-oauth-authz-09)
+- [OCF Specifications](https://openconnectivity.org/developer/specifications)

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -241,7 +241,10 @@ security metadata, rather than repeat it all we simply specify that the OCF mode
 is used.
 
 TO DISCUSS: The other option here would be have a set of options available for CoAP
-security that are rich enough to describe the OCF security model.
+security that are rich enough to describe the OCF security model.  We probably want
+that anyway for non-OCF CoAP systems, so then this tag becomes a convenience for OCF.
+However, in that case, we should also add "convenience" tags for other CoAP-based
+standards (LWM2M, OMA, etc).
 
 ### API Key
  

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -173,10 +173,10 @@ Here is a second example using a proxy configuration:
       "name": "Festo",
       "@id": "urn:dev:wot:festo",
       "security": [{
-          "@id": "proxy-config",
-          "type": "http-proxy",
-          "scheme": "basic",
-          "href": "http://plugfest.thingweb.io:8087"
+        "@id": "proxy-config",
+        "type": "http-proxy",
+        "scheme": "basic",
+        "href": "http://plugfest.thingweb.io:8087"
       }],
       ...
     }

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -263,7 +263,8 @@ at how API keys are used in practice to see if any additional parameters are nee
 Type: "oauth2"
 
 To do. There are also multiple flows: implicit, password, clientCredentials, and authorizationCode.
-Each one may use different kinds of tokens.
+Each one may use different kinds of tokens.  We probably want to model after the [OpenAPI OAuth
+Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oauthFlowObject).
 
 TO DISCUSS: Which flows are relevant?
 

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -293,7 +293,18 @@ The following need to be discussed.
 
 ### Authentication Server Link
 Many of these schemes require use of an authentication server.
-Should the metadata include a link to the authentication server in this case?
+A standard tag should be used for this when it is needed.
+The example from Matthias uses "as".
+
+### Algorithm
+Many of these schemes require use of a specific encryption or hashing algorithm.
+A standard tag should be used for this when it is needed.
+The example from Matthias uses "alg".
+
+### Proxy
+A proxy requires a separate URL to access it.
+A standard tag should be used for this when it is needed.
+The example from Matthias uses "href".
 
 ### Bearer Token Format
 OpenAPI does not specify the terms used to identify different kinds of bearer tokens, since
@@ -301,7 +312,7 @@ they are not created by the client, but by an authentication server.
 Should we be stricter, or not?
 
 ### Cookie API Keys
-Does this even make sense for M2M IoT APIs?
+Does this even make sense for machine to machine IoT APIs?
 
 ### OAuth
 What about other versions of OAuth? What about versions in general?
@@ -315,6 +326,9 @@ and perhaps the amount per use.  Units also need to be specified.   This will of
 combined with other forms of authentication.  While not strictly a security mechanism,
 it may be used as such (although maybe it's something only used indirectly eg at a
 "ticket vending" service, not at individual IoT devices).
+
+NOTE: We should only support this for prototyping reasons,
+as it is not yet fully standards-track (although it is on its way).
 
 ## References
 

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -1,0 +1,117 @@
+# WoT Security Metadata
+
+This is an initial proposal for security metadata to be included in the WoT Thing Description.
+It is intended to be compatible with and equivalent in functionality to several other standards
+and proposals,
+including the 
+[OpenAPI 3.0 Security Object https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject]
+metadata (which includes in turn header and query parameter API keys, common OAuth2 flows, and OpenID.
+Also included are support for OCF access control, Kerberos, Javascript Web Tokens, and Interledger payments.
+
+One requirement is that security should be specifiable both across the entire thing and per-interaction.
+Unfortunately, JSON-LD makes it difficult to take the OpenAPI approach of specifying a global default
+and then per-interaction overrides.
+Therefore, we instead take the approach of allowing the specification of an array of named
+"security configurations" at global scope, and then allowing these specifications to be referenced 
+in the definition of each interaction.
+
+## TD Example
+Before giving the details of each supported scheme, we will give a simple example of a TD using basic
+HTTP authentication for HTTP links and ACL for equivalent CoAP links:
+
+    {
+      "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
+      "@type": ["Thing"],
+      "name": "MyLampThing",
+      "security": [
+        {
+          "id": "simple",
+          "type": "http",
+          "scheme": "basic"
+        },
+        {
+          "id": "acl",
+          "type": "ocf",
+        },
+        {
+          "id": "key",
+          "type": "apikey",
+          "in": "header"
+        }
+      ],
+      "interaction": [
+        {
+          "@type": ["Property"],
+          "name": "status",
+          "schema": {"type": "string"},
+          "writable": false,
+          "observable": true,
+          "form": [
+            {
+              "href": "coaps://mylamp.example.com:5683/status",
+              "mediaType": "application/json",
+              "security": "acl"
+            },
+            {
+              "href": "https://mylamp.example.com/status",
+              "mediaType": "application/json",
+              "security": "simple"
+            },
+          ]
+        },
+        {
+          "@type": ["Action"],
+          "name": "toggle",
+          "form": [
+            {
+              "href": "coaps://mylamp.example.com:5683/toggle",
+              "mediaType": "application/json"
+              "security": ["acl","key"]
+            },
+            {
+              "href": "https://mylamp.example.com/toggle",
+              "mediaType": "application/json"
+              "security": ["simple","key"]
+            }
+          ]
+        },
+        {
+          "@type": ["Event"],
+          "name": "overheating",
+          "schema": {"type": "string"},
+          "form": [
+            {
+              "href": "coaps://mylamp.example.com:5683/oh",
+              "mediaType": "application/json"
+              "security": "acl"
+            },
+            {
+              "href": "https://mylamp.example.com/oh",
+              "mediaType": "application/json"
+            }
+          ]
+        }
+      ]
+    }
+
+In this example, we have three different security configurations: HTTP Basic Authentication,
+OCF access control lists (the CoAP interface is actually to OCF devices), and an API key.
+We also have one case where no security is used (the HTTPS interface to get overheating events)
+and another case where two are required (to turn on the light by CoAP/OCF, we need both
+access rights in the ACL _and_ an API key; the corresponding HTTPS interface needs both
+basic authentication and the key).
+
+Note that security is specified per "form" so that it can be different for each one,
+as is often necessary when multiple protocols are supported for the same interaction,
+since different protocols may support different security mechanisms.
+
+The value in a security object inside a form can be a single string or an object.
+If a string, it is an identifier that refers to a previously declared configuration at the 
+top level.  If an object, it is a local configuration definition.  If an array, then
+a set of configurations may be given, all of which must be satisfied to allow access.
+Arrays can contain strings or objects, or both.
+
+## Detailed Specifications of Configuration Specifications
+To Do.
+
+-

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -5,7 +5,7 @@ It is intended to be compatible with and equivalent in functionality to several 
 and proposals,
 including the 
 [OpenAPI 3.0 Security Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject)
-metadata (which includes in turn header and query parameter API keys, common OAuth2 flows, and OpenID.
+metadata, which includes in turn header and query parameter API keys, common OAuth2 flows, and OpenID.
 Also included are support for OCF access control, Kerberos, Javascript Web Tokens, and Interledger payments.
 
 One requirement is that security should be specifiable both across the entire thing and per-interaction.


### PR DESCRIPTION
This is a strawman for how to specify security metadata in a TD.
Right now the details of individual mechanisms are not given, just an overall example.