### PR TITLE
Updates to Security Metadata Proposal

### DIFF
--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -685,6 +685,7 @@ You would generally include this alongside a separate endpoint authentication sc
 - [RFC7615 - HTTP Authentication-Info and Proxy-Authentication-Info Response Header Fields](https://tools.ietf.org/html/rfc7615)
 - [RFC7616 - HTTP Digest Access Authentication](https://tools.ietf.org/html/rfc7616)
 - [RFC7617 - The 'Basic' HTTP Authentication Scheme](https://tools.ietf.org/html/rfc7617)
+- [IANA HTTP Auth Schemes](http://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml)
 - [RFC7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
 - [RFC7235 Hypertext Transfer Protocol (HTTP/1.1): Authentication](https://tools.ietf.org/html/rfc7235)
 - [RFC6749 The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -454,6 +454,14 @@ method can be used.  In the context of a Thing Description this means that this 
 should only be combined with protocols supporting secure transport,
 eg. COAPS, HTTPS, and the equivalent.
 
+### Digest Authentication
+Scheme: 'digest'
+
+Uses a cryptographic digest, as specified (for HTTP) in RFC7616.   The name can also be used
+for similar schemes in other protocols.
+
+TODO: are any other parameters needed, eg 'in'?
+
 ### OCF Security 
 Scheme: `ocf`
 
@@ -500,12 +508,22 @@ value if the array only has one element.
 We may want to generalize this to other
 standards _or_ define a general mechanism to specify a minimum version.  If we embed versions
 in names, we need a consistent rule to identify versions in schemes that do not have them
-embedded.  OAuth is also a funny special case since we don't intend to support OAuth version 1.
+embedded.  OAuth is also a funny special case since we don't intend to support OAuth version 1
+
+## Omitted Schemes
+Certain schemes listed in the IANA reference for HTTP authentication schemes have been
+omitted (that is, are not provided in the core vocabulary)
+because they are experimental, obsolete, or not recommended (eg insecure).
+These include 'oauth' (version 1; considered obsolete),
+'mutual' (experimental) and 'hoba' (experimental).
 
 ## Other Schemes
 It's not clear we need to support these, so we have left them out of the 
 initial proposal, but we mention them here to provide a starting
 point for discuission.
+
+In general, additional security schemes (including some of the ones noted above as experimental or 
+obsolete) can be specified with custom vocabularies.
 
 ### OpenID Connect
 Scheme: `openIdConnect`

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -231,7 +231,7 @@ expanded, and also with all "single-element" security definitions converted to a
       // default security configuration
       security: [
         {
-	  "scheme": "basic"
+          "scheme": "basic"
         }
       ],
       "properties": {

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -681,6 +681,9 @@ You would generally include this alongside a separate endpoint authentication sc
 
 ## References
 - [OpenAPI 3.0.1](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md)
+- [RFC7235 - Hypertext Transfer Protocol (HTTP/1.1): Authentication](https://tools.ietf.org/html/rfc7235)
+- [RFC7615 - HTTP Authentication-Info and Proxy-Authentication-Info Response Header Fields](https://tools.ietf.org/html/rfc7615)
+- [RFC7616 - HTTP Digest Access Authentication](https://tools.ietf.org/html/rfc7616)
 - [RFC7617 - The 'Basic' HTTP Authentication Scheme](https://tools.ietf.org/html/rfc7617)
 - [RFC7519 JSON Web Token (JWT)](https://tools.ietf.org/html/rfc7519)
 - [RFC7235 Hypertext Transfer Protocol (HTTP/1.1): Authentication](https://tools.ietf.org/html/rfc7235)

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -1,8 +1,8 @@
-ty# WoT Security Metadata (Proposal)
+# WoT Security Metadata (Proposal)
 
 This is a proposal for security metadata to be included in the WoT Thing Description.
 It is intended to be compatible with and equivalent in functionality to
-several other standards and proposals, including the 
+several other standards and proposals, including the
 [OpenAPI 3.0 Security Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject)
 metadata, which includes in turn header and query parameter API keys, common OAuth2 flows, and OpenID.
 
@@ -13,6 +13,7 @@ We also allow the specification of a set of named
 "security configuration definitions" at global scope.
 These definitions can then be referenced and combined
 in the security configurations.
+
 This approach also allows a "OR-AND" approach to security configurations.
 Within each specific
 "form" within an interaction, all security configurations specified need to be met:
@@ -21,15 +22,22 @@ However, multiple form alternatives are possible within an interaction,
 and these can have different security requirements: an OR combination.
 
 This proposal takes advantage of (proposed) JSON-LD 1.1 features.
-This proposal is similar to a new feature being proposed for the TD,
-a "definition" block.  However, we recommend that a separate "securityDefinitions"
-block be used specifically for security definitions.  
-Use of security definitions is, however, merely a convenience feature to
-avoid having to repeat security configurations.  
-In addition, a default security configuration can also be specified
-at the top level of the thing.  This is overridden by any per-form configuration
+This proposal also includes a definitions mechanism similar to a new feature being proposed for the TD,
+a "definition" block.
+However, we recommend that a separate "securityDefinitions"
+block be used specifically for security definitions.
+Use of security definitions is however a convenience feature to
+avoid having to repeat security configurations.
+It is optional and instead all security configurations can be done locally
+in each form.
+
+A global default security configuration can also be specified
+at the top level of the Thing Description.
+This is overridden by any per-form configuration
 but is useful in the case that all interactions in a Thing use the same
 security configuration.
+This also makes this proposal backward-compatible with the current TD
+specification.
 
 ## TD Example
 Before giving the details of each supported security configuration scheme,
@@ -220,19 +228,6 @@ expanded, and also with all "single-element" security definitions converted to a
       "@type": ["Thing","iot:Light","iot:BinarySwitch"],
       "label": "MyLampThing",
       "@id": "urn:dev:wot:my-lamp-thing",
-      // set of named security definitions
-      "securityDefinitions": {
-        "basicConfig": {
-          "scheme": "basic"
-        },
-        "ocfConfig": {
-          "scheme": "ocf"
-        },
-        "apikeyConfig": {
-          "scheme": "apikey",
-          "in": "header"
-        }
-      },
       // default security configuration
       security: [
         {

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -171,7 +171,7 @@ reflects the measured value of a physical property.
 A property may also be immutable for other reasons, for example, immutable configuration
 state such as a ID that can only be set during provisioning.
 The main point is that the `writable` flag is not meant to represent
-a constraint due to access writes.  In particular if some configuration can
+a constraint due to access rights.  In particular if some configuration can
 be updated by an administrator with sufficient access rights, 
 but not by a normal user, it should still be marked as writable.
 

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -1,15 +1,14 @@
 # WoT Security Metadata (Proposal)
 
-This is an initial proposal for security metadata to be included in the WoT Thing Description.
-It is intended to be compatible with and equivalent in functionality to several other standards
-and proposals, including the 
+This is a proposal for security metadata to be included in the WoT Thing Description.
+It is intended to be compatible with and equivalent in functionality to
+several other standards and proposals, including the 
 [OpenAPI 3.0 Security Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#securitySchemeObject)
-metadata, which includes in turn
-header and query parameter API keys, common OAuth2 flows, and OpenID.
+metadata, which includes in turn header and query parameter API keys, common OAuth2 flows, and OpenID.
 Also included are support for
 OCF access control, Kerberos, Javascript Web Tokens, and Interledger payments.
 
-This proposal, unlike the current TD proposed specification, allows different security
+This proposal allows different security
 configurations to be specifiable both across the entire thing and per-interaction
 (actually, per link in each interaction).
 We allow the specification of an array of named
@@ -24,6 +23,12 @@ However, multiple form alternatives are possible within an interaction,
 and these can have different security requirements: an OR combination.
 
 This proposal takes advantage of (proposed) JSON-LD 1.1 features.
+This proposal is similar to a new feature being proposed for the TD,
+a "definition" block.  However, we recommend that a separate "security"
+block be used specifically for security metadata.  The "definitions"
+block is still useful to, for example, create definitions for combinations
+of security configurations suitable to particular roles, thereby
+abstracting security definitions.
 
 ## TD Example
 Before giving the details of each supported security configuration scheme,
@@ -33,24 +38,22 @@ HTTP authentication for HTTPS links and OCF access control lists for equivalent 
     {
       "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
       "@type": ["Thing"],
-      "name": "MyLampThing",
+      "label": "MyLampThing",
       "@id": "urn:dev:wot:my-lamp-thing",
       "security": {
-        "basic-config": {
+        "basicConfig": {
           "scheme": "basic"
         },
-        "ocf-config": {
+        "ocfConfig": {
           "scheme": "ocf"
         },
-        "apikey-config": {
+        "apikeyConfig": {
           "scheme": "apikey",
           "in": "header"
         }
       },
-      "interaction": [
-        {
-          "@type": ["Property"],
-          "name": "status",
+      "properties": {
+        "status": {
           "schema": {"type": "string"},
           "writable": true,
           "observable": true,
@@ -59,53 +62,53 @@ HTTP authentication for HTTPS links and OCF access control lists for equivalent 
               "href": "coaps://mylamp.example.com:5683/status",
               "mediaType": "application/json",
               "method": "coap:get",
-              "security": "ocf-config"
+              "security": "ocfConfig"
             },
             {
               "href": "coaps://mylamp.example.com:5683/status",
               "mediaType": "application/json",
-              "method": "coap:post",
-              "security": ["ocf-config","apikey-config"]
+              "method": "coap:put"
+              "security": ["ocfConfig","apikeyConfig"]
             },
             {
               "href": "https://mylamp.example.com/status",
               "mediaType": "application/json",
               "method": "http:get",
-              "security": "basic-config"
+              "security": "basicConfig"
             },
             {
               "href": "https://mylamp.example.com/status",
               "mediaType": "application/json",
-              "method": "http:post",
-              "security": ["basic-config","apikey-config"]
+              "method": "http:put",
+              "security": ["basicConfig","apikeyConfig"]
             },
           ]
-        },
-        {
-          "@type": ["Action"],
-          "name": "toggle",
+        }
+      },
+      "actions": {
+        "toggle": {
           "form": [
             {
               "href": "coaps://mylamp.example.com:5683/toggle",
               "mediaType": "application/json"
-              "security": ["ocf-config","apikey-config"]
+              "security": ["ocfConfig","apikeyConfig"]
             },
             {
               "href": "https://mylamp.example.com/toggle",
               "mediaType": "application/json"
-              "security": ["basic-config","apikey-config"]
+              "security": ["basicConfig","apikeyConfig"]
             }
           ]
-        },
-        {
-          "@type": ["Event"],
-          "name": "overheating",
+        }
+      },
+      "events": {
+        "overheating": {
           "schema": {"type": "string"},
           "form": [
             {
               "href": "coaps://mylamp.example.com:5683/oh",
               "mediaType": "application/json"
-              "security": "ocf-config"
+              "security": "ocfConfig"
             },
             {
               "href": "https://mylamp.example.com/oh",
@@ -113,7 +116,7 @@ HTTP authentication for HTTPS links and OCF access control lists for equivalent 
             }
           ]
         }
-      ]
+      }
     }
 
 In this example, we have three different security configurations: HTTP Basic Authentication,
@@ -123,22 +126,44 @@ and another case where two are required (to turn on the light by CoAP/OCF, we ne
 access rights in the ACL _and_ an API key; the corresponding HTTPS interface needs both
 basic authentication and the key).
 
-*Note:* Security is specified per `"form"` so that it can be different for each one,
+*Note:* Security is specified per `form` so that it can be different for each one,
 as is often necessary when multiple protocols are supported for the same interaction,
 since different protocols may support different security mechanisms.  In this case we
-also wanted to support stronger security for actions that change the state of the light.
+also wanted to support stronger security (eg multiple authentication mechanisms)
+for actions that change the state of the device.
 
-Since the API also allows changing the state of the light by writing to the `"status"` property,
+Since the API also allows changing the state of the device by writing to the `status` property,
 we specify that "read" access (eg the "GET" method) on this property to has different
-(weaker) security than "write" access (eg the "POST" and "PUT" methods).
+(weaker) security than "write" access (eg "POST" or "PUT" methods).
+
+In general if a property is marked as being writable
+this means it is writable for _some_ user.  Conversely, if it is marked as
+not being writable, it is not writeable by _any_ user, regardless of access rights.
+For example, it does not in general make sense to write to sensors whose state
+reflects the measured value of a physical property.
+A property may also be immutable for other reasons, for example, immutable configuration
+state such as a ID that can only be set during provisioning.
+The main point is that the `writable` flag is not meant to represent
+a constraint due to access writes.  In particular if some configuration can
+be updated by an administrator with sufficient access rights, 
+but not by a normal user, it should still be marked as writable.
+
+**To Discuss**: What if we have "filtered" TDs where a TD is generated for
+a specific class of users?  For example, we might want to have a TD specifically
+for normal users and another for administrators.  The former would omit any
+properties or actions that users cannot access at all.  It _might_ make sense in
+this case to mark properties that no users in the target set can have write
+access to as not being readable.  In other words, the "writable" flag refers
+to the capabilities of all users in the target set.
+
 In this example reads just require basic HTTP authentication
 (or, under OCF, appropriate ACL authorization) but writes in addition require an API key,
-consistent with the actions.
+consistent with the interactions.
 In practice the API key may not be needed to provide this differential access under OCF as the ACL
-can include differential read/write access for different users (although that access is tied to 
+can include differential read/write access for different users.  However, that access is tied to 
 identity, not ownership of the API key, so the additional API key provides an additional 
 layer of security; in particular, an API key can be updated on a device to revoke access to
-everyone with the old key).
+everyone with the old key.
 
 The value in a security object inside a form can be a single string or an object.
 If a string, it is an identifier that refers to a previously declared configuration at the 
@@ -146,27 +171,30 @@ top level.  If an object, it is a local configuration definition.  If an array, 
 a set of configurations may be given, _all_ of which must be satisfied to allow access.
 Arrays can contain strings or objects, or both.
 
-All links in this example use secure transport, i.e. either coaps (CoAP over UDP using DTLS)
+All links in this example use secure transport, i.e. either CoAPS (CoAP over UDP using DTLS)
 or HTTPS (HTTP over TCP using TLS).
 These transports use certificates for mutual authentication, secure session key exchange,
 and of course encrypted transport.  In fact, use of such encrypted transport is essential
 for many authorization schemes, such as basic HTTP authentication, which transmits a
-username and password in the clear in the header.  This is only secure if the header is
+username and password "in the clear" in the header.  This is only secure if the header is
 encrypted by an outer transport layer.  Likewise, other authentication mechanisms not
-used in this example, such as tokens, also rely on secure transport to protect against
-certain forms of attack.  The security configuration metadata in this example focuses on 
-authentication.  
+used in this example, such as bearer tokens, also rely on secure transport to protect against
+certain forms of attack, since an intercepted bearer token could be used by an attacker to gain
+access to the device.  The security configuration metadata in this example focuses on 
+authentication, but in general the goal is authorization (providing access rights) to
+authenticated users.
 
-*To discuss:* In this example, it is assumed that issues such as certificate authentication
+**To discuss:** In this example, it is assumed that issues such as certificate authentication
 for TLS can be handled by TLS itself, although it may use other information 
-in the TD (for example, a UUID) to validate identity.   This is useful in situations where
+in the TD (for example, a UUID or other value in the `@id` field) to validate identity.
+This is useful in situations where
 normal certificate validation cannot be performed, eg semi offline systems.
 
 ## Additional Examples:
-Matthias Kovatsc has [documented how the current version of 'node-wot' implements certain
+Matthias Kovatsc has [documented how 'node-wot' circa March 2018 implemented certain
 security mechanisms](https://github.com/w3c/wot-security/issues/73).
-His example includes several additional mechanisms not covered by the above,
-including tokens and proxies.  Here are his two examples as they would be
+His example included several additional mechanisms,
+including tokens and proxies.  Here are two of his examples as they would be
 expressed under the current proposal.
 
 ### Bearer Tokens
@@ -175,10 +203,10 @@ Here is an example (based on Matthias' example, above) using bearer tokens:
     {
       "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
       "@type": ["Thing"],
-      "name": "FujitsuBeacon",
+      "label": "FujitsuBeacon",
       "@id": "urn:dev:wot:fujitsu-beacon",
       "security": {
-        "bearer-token-config": {
+        "bearerTokenConfig": {
           "scheme": "bearer",
           "format": "jwt",
           "alg": "ES256",
@@ -187,23 +215,29 @@ Here is an example (based on Matthias' example, above) using bearer tokens:
         ... // other security configurations, if needed
       },
       ...
-      "interaction": [
-        {
+      "properties": {
+        "status": {
           "form": [
             {
               ...
-              "security": "bearer-token-config"
+              "security": "bearerTokenConfig"
             },
             ... // other forms
         },
-        ... // other interactions
-      ]
+        ... // other properties
+      },
+      ... // other interactions
     }
 
 As shown, in each form under interactions there would have to be
-a `"security" : "bearer-token-config"` entry.  As bearer tokens need
+a `"security" : "bearerTokenConfig"` entry.  As bearer tokens need
 to be protected from interception they should only be used in combination with
 secure transport.
+
+**To Discuss**: Should TD validation flag insecure 
+configurations, such as basic authentication or bearer tokens
+combined with non-encrypted transports?  These could be warnings
+rather than errors, since they might be useful during development.
   
 ### Proxies
 Here is a second example using a proxy configuration:
@@ -211,35 +245,46 @@ Here is a second example using a proxy configuration:
     {
       "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
       "@type": ["Thing"],
-      "name": "Festo",
+      "label": "Festo",
       "@id": "urn:dev:wot:festo",
       "security": {
-        "proxy-config": {
+        "proxyConfig": {
           "scheme": "basic",
-          "proxy": "http://plugfest.thingweb.io:8087"
+          "proxyUrl": "http://plugfest.thingweb.io:8087"
         },
-        "endpoint-config": {
+        "endpointConfig": {
           ... // details omitted; independent of proxy configuration
         },
         ... // other security configurations, if needed
       },
+      "definitions": {
+        "propertySecurityConfig": ["proxyConfig","endpointConfig"],
+        // other definitions
+      },
       ...
-      "interaction": [
-        {
+      "properties": {
+        "status": {
+          ...
           "form": [
             {
               ...
-              "security": ["proxy-config","endpoint-config"]
+              "security": "propertySecurityConfig"
             },
             ... // other forms
+          ]
         },
-        ... // other interactions
-      ]
+        ... // other properties
+      },
+      ... // other interactions
     }
 
 As above, each form under interactions 
-would have to include a `"proxy-config"` _and_ an `"endpoint-config"`
-reference in its `"security"` tag.
+would have to include a _both_ a `proxyConfig` _and_ an `endpointConfig`
+reference in its `security` field.
+We make use of the new definitions feature here to
+avoid having to repeat such combinations in every form that uses them;
+the two configurations are combined into one using an array `propertySecurityConfig`
+declared under `definitions`.
 Multiple proxy configuration and endpoint configurations could also
 be included in a single Thing Description.
 In this example, the details of the endpoint security configuration have 
@@ -253,10 +298,11 @@ This example uses an OAuth authorization code flow.
     {
       "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld"],
       "@type": ["Thing"],
-      "name": "Camera",
+      "label": "Camera",
       "@id": "urn:dev:wot:camera",
+      "base": ...,
       "security": {
-        "oauth-config": {
+        "oauthConfig": {
           "scheme": "oauth2",
           "flow": "code",
           "authorizationUrl": "https://example.com/api/oauth/dialog",
@@ -270,69 +316,61 @@ This example uses an OAuth authorization code flow.
         ... // other security configurations, if needed
       },
       ...
-      "interaction": [
-        {
-          "@type": ["Property"],
-          "name": "frame",
-          ...
+      "properties": {
+        "frame": {
           "writable": false,
           "observable": true,
           "form": [
             {
-              "href": "https://example.com/api/frame",
+              "href": "/api/frame",
               "mediaType": "image/jpeg",
               "method": "http:get",
-              "security": ["oauth-config"],
-              "scope": ["read:frame"]
+              "security": "oauthConfig",
+              "scope": "read:frame"
             },
             ... // other forms
         },
-        ... // other interactions
-      ]
+        ... // other properties
+      },
+      ... // other interactions
     }
 
-*To discuss:* OpenAPI also allows a description in various places, for example
-associated with the scopes of an OAuth flow.  This would be useful to include as 
-well but since it would also be useful elsewhere, should be part of a more general 
-discussion.
+Here we see that an additional field is used for OAuth flows, `scope`.
+This could be generalized to other authentication mechanisms to restrict
+application of a security mechanism to those with matching scope definitions.
 
 ### Comments
 A few comments:
-- A Thing ID (encoded under some top-level tag, such as `"@id"`, as shown)
+- A Thing ID (encoded under some top-level tag, such as `@id`, as shown)
   is needed in order for tokens to work (they have to encode some identity).
-- The `"authorization"` tag in Matthias' example was changed to `"scheme"` 
+- The `authorization` tag in Matthias' example was changed to `scheme` 
   to be more consistent with this proposal's tag vocabulary, which is based on OpenAPI.
-  Unlike OpenAPI, however, we only use a single name for the `"scheme"` and it is actually
-  the combination of the `"scheme"` with the protocol used in a particular form that determines
-  the final authentication mechanism.
+  At any rate, it is more consistent to talk about _authorization_, but use of
+  `scheme` avoids any confusion.
+  Unlike OpenAPI, however, we only use a single name for the `scheme` and it is actually
+  the combination of the `scheme` with the protocol used in a particular form that determines
+  the actual security mechanism.
     - For example, `"basic"` authentication means clear-text user name and password,
       but this will be instantiated in different ways in MQTT and HTTP.
-- *To discuss:* 
+- **To discuss:** 
   It is still necessary to refer to the name of the security configuration in each interaction.
   We might be able to use a rule like "the first security scheme mentioned is the default" as 
   long as we can make this work with JSON-LD.
 - In general security configurations have a set of "extra" parameters that depend on their type
   and scheme. Several of these tags, however, are used in more than one scheme.
-    - For example, many schemes have references to an authentication server, and in general this
-      is referenced by a URL given in the `"as"` tag.
+    - For example, many schemes have references to an authentication server.
 - If a security configuration is intended for a proxy this is indicated by giving a value (a URL)
-  to the `"proxy"` tag.  If no such value is given, then the configuration is intended for the 
+  to the `proxyUrl` tag.  If no such value is given, then the configuration is intended for the 
   endpoint.
-    - *To discuss:* whether this can be made to work with JSON-LD.
-- *To discuss:* If we can use default values, it would be nice to automatically
-  give the @id for a security configuration the same name as the scheme, if it is unique.
-    - In the example above we generally use the name of the scheme followed by `"-config"`
-      although in general the value of the `"@id"` for a security configuration is arbitrary,
-      and there could be multiple configurations using the same scheme but with different
-      parameters.
 
 ## Detailed Specifications of Configurations
-Each configuration is identified with a `"scheme"` which currently must be one of the following:
-- `"basic"`: Clear-text username and password (must be encapsulated in encrypted transport)
-- `"ocf"`: OCF security model (access control lists with authentication servers and tickets)
-- `"apikey"`: API key (opaque strings)
-- `"token"`: bearer token (format given by the value of a "format" tag) 
-- `"oauth2"`: OAuth2.0 authentication flows
+Each configuration is identified with a `scheme` which currently must be one of the following:
+- `basic`: Clear-text username and password (must be encapsulated in encrypted transport)
+- `ocf`: OCF security model (access control lists with authentication servers and tickets)
+- `apikey`: API key (opaque strings)
+- `bearer`: bearer token (format given by the value of a `format` field) 
+- `pop`: proof of possession token (format given by the value of a `format` field) 
+- `oauth2`: OAuth2.0 authentication flows (no support for OAuth1.0, however; see OpenAPI discussion)
 
 For each scheme, additional parameters may be required.
 These are specified in the corresponding sections below. 
@@ -342,30 +380,32 @@ These are specified in the corresponding sections below.
   not an authorization scheme. However, it might be used by an authorization server to
   identify a user, and we assume authentication services will be implemented by other means,
   eg web services with metadata in OpenAPI.  
-    - *To discuss:* can a Thing be an authentication server?
+    - **To discuss:** can a Thing be an authentication server?
 - In general we have tried to use generic tags identifying authorization schemes that are
   orthogonal to protocols.
-    - For example, in theory, `"basic"` authentication can be combined with several transport
+    - For example, in theory, `basic` authentication can be combined with several transport
       protocols, such as HTTPS and MQTT, although it is only secure if that transport is
       previously encrypted by other means.
     - This also raises a validation question:
       combining certain authentication schemes with certain protocols should be considered an
       error.
-- OCF has its own scheme label since it has an authentication scheme specific to OCF,
+- OCF is an exception.  It has its own scheme label since it has an authentication scheme specific to OCF,
   even though it is built on top of the ACE specification.  OCF authorization and communication
   can also take place over multiple protocols (COAPS and HTTPS).
+    - **To discuss:** we may want to add an `ace` scheme with an appropriate set of parameters.
 - This is not a closed set. In particular, additional tags may be needed for additional schemes
   specific to particular ecosystems: OneM2M, OPC-UA, MQTT, AWS IoT, HomeKit, etc. or supported
-  by additional standards.
+  by additional standards.  Whenever possible new schemes should reuse parameter vocabulary
+  already defined and be defined in a way orthogonal to transport protocols.
 
 ### Basic Authentication
-Scheme: `"basic"`
+Scheme: `basic`
 
 In the basic authentication scheme, a username and password are provided in plaintext,
 using a mechanism specific to the protocol.  Additional parameters may be necessary for
 some protocols as follows:
-- `"https"`:
-    - `"in"`: specifies location of authentication information.  See defintion below.
+- `https`:
+    - `in`: specifies location of the authentication information.  See defintion below.
 
 Since the username and password used in this scheme are in plaintext, they need
 to be sent via a mechanism that provides transport security, such as TLS.  In the case of HTTP,
@@ -375,7 +415,7 @@ should only be combined with protocols supporting secure transport,
 eg. COAPS, HTTPS, and the equivalent.
 
 ### OCF Security 
-Scheme: `"ocf"`
+Scheme: `ocf`
 
 OCF mandates a specific security model, including ACLs (access control lists),
 an authentication server, and tickets.
@@ -383,43 +423,44 @@ As OCF itself defines a set of standard introspection mechanisms to discover
 security metadata, including the location of authorization servers, 
 rather than repeat it all we simply specify that the OCF model is used.
 
-*Note:* We should build prototypes to discover if additional configuration parameters are needed
+**Note:** We should build prototypes to discover if additional configuration parameters are needed
 in practice.
 
 ### API Key
-Scheme: `"apikey"`
+Scheme: `apikey`
 
 The key can be given in either the header or in the 
-body, as indicated by the value of the "in" field (see definition below).
+body, as indicated by the value of the `in` field (see definition below).
 
 By definition an API key is opaque.  If the key is not opaque it should be considered a token.
 
 ### OAuth2.0
-Scheme: `"oauth2"`
+Scheme: `oauth2`
 
-In general OAuth supports multiple flows, indicated with the `"flow"` tag, which has 
+In general OAuth2 supports multiple flows, indicated with the `flow` field, which has 
 one of the following values:
-- `"implicit"`: also requires `"authorizationUrl"` and `"scope"` array.
-- `"password"`: also requires `"tokenUrl"` and `"scope"` array.
-- `"client"`: also requires `"tokenUrl"` and `"scope"` array.
-- `"code"`: requires both `"authorizationUrl"` and `"tokenUrl"` URLs and `"scope"` array.
+- `implicit`: also requires `authorizationUrl` and `scope` array.
+- `password`: also requires `tokenUrl` and `scope` array.
+- `client`: also requires `tokenUrl` and `scope` array.
+- `code`: requires both `authorizationUrl` and `tokenUrl` URLs and `scope` array.
 
 This is modelled after the [OpenAPI OAuth
 Flow Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oauthFlowObject) 
 specification.
-In partiuclar we use `"authorizationUrl"` and `"tokenUrl"` to be consistent with OpenAPI.
-In addtion to the above required values, all flows may also have a 
-`"refreshUrl"`. 
+In partiuclar we use the names `authorizationUrl` and `tokenUrl` to be consistent with OpenAPI.
+In addition to the above required values, all flows may also have a 
+`refreshUrl`. 
 
 All flows require an array of scopes.  These are a set of strings giving a name to each scope.
-Within each form of an interaction, an additional `"scope"` tag is needed giving an array
-of authorized scopes.
+Within each form of an interaction, an additional `scope` field is needed giving an array
+of authorized scopes.  Note that the value of the `scope` field may be reduced to a single
+value if the array only has one element.
 
-*To discuss:* Note that the version is embedded in the name.
+**To discuss:** Note that the version is embedded in the name.
 We may want to generalize this to other
 standards _or_ define a general mechanism to specify a minimum version.  If we embed versions
 in names, we need a consistent rule to identify versions in schemes that do not have them
-embedded.
+embedded.  OAuth is also a funny special case since we don't intend to support OAuth version 1.
 
 ## Other Schemes
 It's not clear we need to support these, so we have left them out of the 
@@ -427,34 +468,35 @@ initial proposal, but we mention them here to provide a starting
 point for discuission.
 
 ### OpenID Connect
-Scheme: `"openIdConnect"`
+Scheme: `openIdConnect`
 
 This is provided for in OpenAPI but is an identification (authentication) scheme, whereas
 for Thing interactions we are generally interested in authorization.  OpenIdConnect is 
 also user-oriented.  It seems more appropriate to only support this on authorization servers.
 
-If this is supported, it would also use the `"scope"` and `"auth"` tags defined for OAuth.
+If this is supported, it would also use the `scope` and `authorizationUrl` fields defined for OAuth.
 
-*To discuss:* we may want to support this if Things can act as authentication servers.
+**To discuss:** we _may_ want to support this if Things can act as authentication servers.
 
 ### Interledger
-Scheme: `"interledger"`
+Scheme: `interledger`
 
 Interledger can support pay-for-use services and deposit-based trust.
 In addition to the address, it is necessary to specify the amount of deposit required,
 and perhaps the amount per use.  Units also need to be specified.   This will often be
 combined with other forms of authentication.  While not strictly a security mechanism,
-it may be used as such (although maybe it's something only used indirectly eg at a
+it may be used as such (although maybe it's something only used indirectly e.g. at a
 "ticket vending" service, not at individual IoT devices). 
 
-*To discuss:* Supporting this as an experimental authentication scheme, perhaps alongside
+**To discuss:** Supporting this as an experimental authentication scheme, perhaps alongside
 other schemes based on permissioned blockchain (eg hyperledger).
 
-## Generic Tags
-This section defines a set of parameters that can be used with one or more security configurations.
+## Security Parameter Vocabulary
+This section defines terms used to identify 
+parameters that can be used with one or more security configurations.
 
 ### Authorization Server Link
-Tag: `"authorizationUrl"`
+Tag: `authorizationUrl`
 
 For authentication schemes requiring the use of an authorization server to obtain
 tokens or keys.
@@ -462,52 +504,54 @@ tokens or keys.
 Value: URL specifying the location of the authorization server.
 
 ### Token Server Link
-Tag: `"tokenUrl"`
+Tag: `tokenUrl`
 
 For authentication schemes requiring the use of an token server to obtain
 tokens or keys.
 
 Value: URL specifying the location of the token server.
 
-*Note:* the OAuth code flow, as well as Kerberos, have multiple authorization servers.
+**Note:** the OAuth code flow, as well as Kerberos, have multiple authorization servers.
 The first provides a ticket-granting ticket, the second actually provides this tickets.
-This is done for reasons of scalability.
+This is done for reasons of scalability.  This may be optional if the information
+is provided by the authentication server.
 
 ### Refresh Server Link
-Tag: `"refreshUrl"`
+Tag: `refreshUrl`
 
 For authentication schemes requiring the use of an token server to obtain
 refreshed tokens or keys.
 
 Value: URL specifying the location of the refresh server.  This only needs to be
-provided in general if it is different from the `"tokenUrl"`.
+provided in general if it is different from the `tokenUrl`.  It is also optional
+since usually the information is provided a by the authorization server.
 
-### Authentication Scopes
-Tag: `"scope"`
+### Authorization Scopes
+Tag: `scope`
 
-Value: an array of strings used to identify different roles for 
-interactions.
+Value: an array of strings used to identify different roles for interactions.
 
-If used, each form also needs a `"scope"` tag (which can be
+If used, each form also needs a `scope` tag (which can be
 an array or a single value) specifying the
 authorization roles it can be used with.
 
-*To discuss:* Would an implied default value for `"scope"` be useful here?  For example,
+**To discuss:** Would an implied default value for `scope` be useful here?  For example,
 if not given, it could be assumed that an interaction can be used with all scopes.
 
 ### Algorithm
-Tag: `"alg"`
+Tag: `alg`
 
-Many schemes require use of a specific encryption or hashing algorithm.
+Many schemes require use of a specific encryption or hashing algorithm, or 
+combination of algorithms.  This is usually referred to as a "ciphersuite".
 
-Value: String specifying the cipher suite used.  One of:
-- `"ES256"`: SHA-256 ciphersuite.
+Value: String specifying the ciphersuite used.  One of:
+- `ES256`: SHA-256 ciphersuite.
 
-*To do:* we should indicate a set of additional valid values for this based on existing RFCs
+**To do:** we should indicate a set of additional valid values for this based on existing RFCs
 and standards.
 
 ### Proxy
-Tag: `"proxy"`
+Tag: `proxyUrl`
 
 For protocols that support proxies, the proxy may have its own authentication scheme
 separate from that of the endpoint.  If a security configuration includes a value
@@ -517,80 +561,81 @@ endpoint.
 Value: URL of the proxy.
 
 ### Format
-Tag: `"format"`
+Tag: `format`
 
-Some authentication schemes have options for how data is to be encoded, for example,
-there might be differnet formats for how tokens are encoded.  This tag indicates how
+Some authentication schemes have options for how data is to be encoded, in particular,
+there might be different formats for how tokens are encoded.  This tag indicates how
 the data for a scheme is encoded.  Valid values depend on the scheme.
 
 For the `"token"` scheme, the value is one of 
 - `"jwt"`: JSON Web Token 
     
-*Note:* The format tag is only used in one place for now and when used currently only has
-one legal value.  This is a temporary situation and we expect `"format"`
+**Note:** The format tag is only used in one place for now and when used currently only has
+one legal value.  This is a temporary situation and we expect `format`
 to be used in multiple schemes and also to be used to express multiple formats for tokens 
 in the future.
 
 ### In
-Tag: `"in"`
+Tag: `in`
 
 Location of information in a particular protocol.
 
 Value is one of
-- `"header"`: in protocol header
-- `"parameter"`: the key is added to the url as a query parameter
-- `"body"`: in payload body
-- `"cookie"`: in data maintained by the client and sent automatically with each transaction
+- `header`: in protocol header
+- `parameter`: the key is added to the url as a query parameter
+- `body`: in payload body
+- `cookie`: in data maintained by the client and sent automatically with each transaction
   (typically also in the header, but in a different field)
 
-*Note:* The `"parameter"` option requires manipulation of the URL.  In this case the URL given
-in the `"href"` parameter is just considered the base URL.
+**Note:** The `parameter` option requires manipulation of the URL.  In this case the URL given
+in the `href` parameter is just considered the base URL.
 
 ### Name
-Tag: `"name"`
+Tag: `name`
 
 The name to be used for a header, query parameter, or cookie.  In the case of a header
 this can be omitted if there is a useful default.
 
+**To discuss:** Should this be `label`?  However, `name` is consistent with OpenAPI.
+
 ## Protocol-Specific Notes
 Schemes only resolve into specific security mechanisms when combined with specific protocols.
 Right now only the following combinations are supported:
-- `"basic"`+`"https"`: Basic HTTP Authentication
-    - When used in combination with a "proxy" tag indicates Basic HTTP Proxy Authentication
-- `"token"`+`"https"`: requires a `"format"' tag as well
-- `"token"`+`"coaps"`: requires a '"format"' tag as well
-- `"apikey"`+`"https"`
-- `"apikey"`+`"coaps"`
-- `"ocf"`+`"coaps"`
+- `basic`+`https`: Basic HTTP Authentication
+    - When used in combination with a `proxyUrl` tag indicates Basic HTTP Proxy Authentication
+- `bearer`+`https`: requires a `format' tag as well
+- `bearer`+`coaps`: requires a 'format' tag as well
+- `pop`+`https`: requires a `format' tag as well
+- `pop`+`coaps`: requires a 'format' tag as well
+- `apikey`+`https`
+- `apikey`+`https`
+- `apikey`+`coaps`
+- `ocf`+`coaps`
 
-*To discuss:* Other combinations may make sense, for example, basic authentication under COAPS,
+**To discuss:** Other combinations may make sense, for example, basic authentication under COAPS,
 tokens and api keys with non-encrypted transports (maybe, if the tokens are self-protected
 somehow), and support for additional protocols (for example, MQTT).
 
 ### HTTP
 The standard HTTP security models can be specified by
 using the following schemes. 
-- `"basic"`: simple (basic) authentication
-- `"bearer"`: bearer token
-- `"pop"`: proof-of-possession token
+- `basic`: simple (basic) authentication
+- `bearer`: bearer token
+- `pop`: proof-of-possession token
 Please refer to [RFC7235 https://tools.ietf.org/html/rfc7235#section-5.1].
-If basic authentication is used, the location should be specified using the `"in"` tag.
-If no value is given for this, `"header"` is assumed.
-If a token is used, its format must be specified using `"format"`, which should
-have one of the following values:
-- `"jwt"`: JSON Web Token
+If basic authentication is used, the location should be specified using the `in` tag.
+If no value is given for this, `header` is assumed.
+If a token is used, its format must be specified using `format`.
 
-*Notes:* 
-- There is only one format for tokens supported now, but this set will
-  likely be expanded in the future.
+**Notes:** 
 - Basic authentication assumes defaults whose values actually depend on the protocol
-  it is combined with.  
-    - *To discuss:* whether this will work with JSON-LD. 
+  it is combined with, and whether a proxy is being used.  
+    - **To discuss:** whether this will work with JSON-LD. 
 
 ### HTTP Proxy Authentication
-This takes the same values as `"http"` but is targeted at the proxy, not the endpoint.
+This takes the same values as `http` but is targeted at the proxy, not the endpoint.
 In this case, in addition to the standard configuration, a URL specifying the proxy
-should be given as the value of a `"proxy"` tag.
+should be given as the value of a `proxy` tag.
 You would generally include this alongside a separate endpoint authentication scheme 
 (eg you would use an array of security configurations in each form using the proxy).
 

--- a/wot-security-metadata.md
+++ b/wot-security-metadata.md
@@ -322,7 +322,7 @@ Proxy authentication is handled separately from
 endpoint configuration in any case.
 
 ### OAuth
-This example uses an OAuth authorization code flow.
+This example uses an OAuth 2 authorization code flow.
 
     {
       "@context": ["https://w3c.github.io/wot/w3c-wot-td-context.jsonld",...],
@@ -406,6 +406,7 @@ A few comments:
 ## Detailed Specifications of Configurations
 Each configuration is identified with a `scheme` which currently must be one of the following:
 - `basic`: Clear-text username and password (must be encapsulated in encrypted transport)
+- `digest`: Encrypted username and password (can with used with unencrypted transport)
 - `ocf`: OCF security model (access control lists with authentication servers and tickets)
 - `apikey`: API key (opaque strings)
 - `bearer`: bearer token (format given by the value of a `format` field) 
@@ -455,12 +456,12 @@ should only be combined with protocols supporting secure transport,
 eg. COAPS, HTTPS, and the equivalent.
 
 ### Digest Authentication
-Scheme: 'digest'
+Scheme: `digest`
 
 Uses a cryptographic digest, as specified (for HTTP) in RFC7616.   The name can also be used
 for similar schemes in other protocols.
 
-TODO: are any other parameters needed, eg 'in'?
+TODO: are any other parameters needed, eg `in`?
 
 ### OCF Security 
 Scheme: `ocf`
@@ -514,8 +515,8 @@ embedded.  OAuth is also a funny special case since we don't intend to support O
 Certain schemes listed in the IANA reference for HTTP authentication schemes have been
 omitted (that is, are not provided in the core vocabulary)
 because they are experimental, obsolete, or not recommended (eg insecure).
-These include 'oauth' (version 1; considered obsolete),
-'mutual' (experimental) and 'hoba' (experimental).
+These include `oauth` (version 1; considered obsolete),
+`mutual` (experimental) and `hoba` (experimental).
 
 ## Other Schemes
 It's not clear we need to support these, so we have left them out of the 
@@ -625,8 +626,8 @@ Some authentication schemes have options for how data is to be encoded, in parti
 there might be different formats for how tokens are encoded.  This tag indicates how
 the data for a scheme is encoded.  Valid values depend on the scheme.
 
-For the `"token"` scheme, the value is one of 
-- `"jwt"`: JSON Web Token 
+For the `token` scheme, the value is one of 
+- `jwt`: JSON Web Token 
     
 **Note:** The format tag is only used in one place for now and when used currently only has
 one legal value.  This is a temporary situation and we expect `format`
@@ -661,10 +662,14 @@ Schemes only resolve into specific security mechanisms when combined with specif
 Right now only the following combinations are supported:
 - `basic`+`https`: Basic HTTP Authentication
     - When used in combination with a `proxyUrl` tag indicates Basic HTTP Proxy Authentication
-- `bearer`+`https`: requires a `format' tag as well
-- `bearer`+`coaps`: requires a 'format' tag as well
-- `pop`+`https`: requires a `format' tag as well
-- `pop`+`coaps`: requires a 'format' tag as well
+- `digest`+`http`: Digest HTTP Authentication
+    - When used in combination with a `proxyUrl` tag indicates Digest HTTP Proxy Authentication
+- `digest`+`https`: Digest HTTPS Authentication
+    - When used in combination with a `proxyUrl` tag indicates Digest HTTPS Proxy Authentication
+- `bearer`+`https`: requires a `format` tag as well
+- `bearer`+`coaps`: requires a 'format` tag as well
+- `pop`+`https`: requires a `format` tag as well
+- `pop`+`coaps`: requires a `format` tag as well
 - `apikey`+`https`
 - `apikey`+`https`
 - `apikey`+`coaps`
@@ -678,6 +683,7 @@ somehow), and support for additional protocols (for example, MQTT).
 The standard HTTP security models can be specified by
 using the following schemes. 
 - `basic`: simple (basic) authentication
+- `digest`: digest authentication
 - `bearer`: bearer token
 - `pop`: proof-of-possession token
 Please refer to [RFC7235 https://tools.ietf.org/html/rfc7235#section-5.1].


### PR DESCRIPTION
- Allow name:value pairs for security configurations, enabled by JSON-LD 1.1 frames
- Convert as -> authorizationUrl, ts -> tokenUrl, and rs -> refreshUrl.   The shorter names are nicer but "rs" has a conflict with "Resource Server" that it is best to avoid, and these names are consistent with OpenAPI.