### PR TITLE
Update IETF references, clean up whitespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,13 +121,6 @@
                   , title: "Authentication Protocols, Web UX and Web API"
                   , date: "April 2014"
                 },
-                "Bor14": {
-                  authors: ["C. Bormann", "et al."]
-                  , href: "https://tools.ietf.org/rfc/rfc7228.txt"
-                  , title: "Terminology for Constrained-Node Networks"
-                  , publisher: "IETF RFC 7228"
-                  , date: "May 2014"
-                },
                 "Bru14": {
                   authors: ["C. Brubaker", "et al."]
                   , href: "https://www.cs.utexas.edu/~shmat/shmat_oak14.pdf"
@@ -2103,7 +2096,7 @@ tracking equipment, information about user's preferences in home environment, vi
       <li>[[Bel89]] - <cite>Security Problems in the TCP-IP Protocol Suite</cite></li>
       <li>[[Bel13]] - <cite>Web Security in the Real World</cite></li>
       <li>[[Ber14]] - <cite>Authentication Protocols, Web UX and Web API</cite></li>
-      <li>[[Bor14]] - <cite>Terminology for Constrained-Node Networks</cite></li>
+      <li>[[RFC7228]] - <cite>Terminology for Constrained-Node Networks</cite></li>
       <li>[[Bru14]] - <cite>Using Frankencerts for Automated Adversarial Testing of Certificate Validation in SSL/TLS Implementations</cite></li>
       <li>[[Dur13]] - <cite>Analysis of the HTTPS Certificate Ecosystem</cite></li>
       <li>[[Ell00]] - <cite>Ten Risks of PKI: What You’re not Being Told about Public Key Infrastructure</cite></li>

--- a/index.html
+++ b/index.html
@@ -61,12 +61,6 @@
                 }
               ]
             , localBiblio: {
-                "AEAD08": {
-                  href: "https://tools.ietf.org/html/rfc5116"
-                , title: "An Interface and Algorithms for Authenticated Encryption"
-                , publisher: "IETF"
-                , date: "January 2008"
-                },
                 "Ocf17": {
                   href: "https://openconnectivity.org/specs/OCF_Security_Specification_v1.0.0.pdf"
                 , title: "The OCF Security Specification, version 1.0.0"
@@ -2380,7 +2374,7 @@ tracking equipment, information about user's preferences in home environment, vi
 		     <ul>
                          <li>Confidentiality without authenticity (i.e. encryption-only) does not provide a secure scheme.
 		             Use authenticated encryption, not encryption-only to provide confidentiality</li>
-                         <li>Classical cryptographic schemes (pre-AEAD, see [[AEAD08]]) cover encryption-only as well as
+                         <li>Classical cryptographic schemes (pre-AEAD, see [[RFC5116]]) cover encryption-only as well as
 		             authentication-only. This requires users of cryptographic schemes to create an own design to
 			     deliver authenticated encryption and this tends to go wrong. Use AEAD schemes to deliver
 		             authenticated encryption (or use an underlying security protocol such as (D)TLS – when this can

--- a/index.html
+++ b/index.html
@@ -80,12 +80,6 @@
                 , publisher: "OCF"
                 , date: "June 2017"
                 },
-		"JWS15": {
-                  href: "https://tools.ietf.org/html/rfc7515"
-                , title: "JSON Web Signature (JWS)"
-                , publisher: "IETF"
-                , date: "May 2015"
-                },
                 "JWT15": {
                   href: "https://tools.ietf.org/html/rfc7519"
                 , title: "JSON Web Token (JWT)"
@@ -2405,7 +2399,7 @@ tracking equipment, information about user's preferences in home environment, vi
 	             Authentication Codes (MACs, using symmetric cryptographic primitives). Such digital signatures or
 		     MACs are created by the producers/issuers of the objects and validated by consumers of the objects
 		     (which should reject signed the objects whose signatures/MACs are invalid). For data expressed in
-		     JSON, [[JWS15]] provides a guideline for expressing digital signatures or MACs as well as related
+		     JSON, [[RFC7515]] provides a guideline for expressing digital signatures or MACs as well as related
 		     security metadata using JSON-based data structures. [[RFC9052]] does the same for CBOR.</li>
                  <li>If confidentiality is desired for exchanged application data, then encrypt WoT objects using well-known
 		     encryption primitives. For data expressed in JSON, [[RFC7516]] provides a guideline for expressing

--- a/index.html
+++ b/index.html
@@ -67,13 +67,6 @@
                 , publisher: "IETF"
                 , date: "January 2008"
                 },
-		"CoRE-RD": {
-                  href: "https://tools.ietf.org/html/draft-ietf-core-resource-directory-11"
-                , title: "CoRE Resource Directory"
-                , status:    "Internet-Draft"
-                , publisher: "IETF"
-                , date: "03 July 2017"
-                },
                 "Ocf17": {
                   href: "https://openconnectivity.org/specs/OCF_Security_Specification_v1.0.0.pdf"
                 , title: "The OCF Security Specification, version 1.0.0"
@@ -2092,7 +2085,7 @@ tracking equipment, information about user's preferences in home environment, vi
     </p><p>
       Additional references:
       <ul>
-      <li>[[CoRE-RD]] - <cite>CoRE Resource Directory</cite></li>
+      <li>[[RFC9176]] - <cite>CoRE Resource Directory</cite></li>
       <li>[[Bel89]] - <cite>Security Problems in the TCP-IP Protocol Suite</cite></li>
       <li>[[Bel13]] - <cite>Web Security in the Real World</cite></li>
       <li>[[Ber14]] - <cite>Authentication Protocols, Web UX and Web API</cite></li>

--- a/index.html
+++ b/index.html
@@ -67,20 +67,6 @@
                 , publisher: "OCF"
                 , date: "June 2017"
                 },
-                "CBOR17": {
-                  href: "https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf"
-                , title: "CBOR Web Token (CWT)"
-                , status:    "Internet-Draft"
-                , publisher: "IETF"
-                , date: "June 2017"
-                },
-                "OSCOAP17": {
-                  href: "https://tools.ietf.org/pdf/draft-ietf-core-object-security-04.pdf"
-                , title: "Object Security of CoAP (OSCOAP)"
-                , status:    "Internet-Draft"
-                , publisher: "IETF"
-                , date: "July 2017"
-                },
                 "Bel89": {
                   authors: ["S. Bellovin"]
                 , href: "https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf"
@@ -2469,7 +2455,7 @@ tracking equipment, information about user's preferences in home environment, vi
 		    These are recommended for devices that are able to use the HTTP protocol and
 		    do not have significant resource constraints.</li>
             <li><strong>Proof-of-possession (PoP) tokens.</strong> These are extensions of the OAuth 2.0-based
-		    access tokens that follow the CBOR web token (CWT) format [[CBOR17]].
+		    access tokens that follow the CBOR web token (CWT) format [[RFC8392]].
 		    The IETF Authentication and Authorization for Constrained Environments (ACE)
 		    specification draft [[IETFACE]]
 		    recommends such tokens for resource-constrained devices using the COAP protocol

--- a/index.html
+++ b/index.html
@@ -118,11 +118,6 @@
                   , publisher: "Proc. 10th USENIX Security Symposium"
                   , date: "August 2001"
                 },
-                "Garcia17": {
-                  authors: ["O. Garcia-Morchon", "S. Kumar", "M. Sethi"]
-                  , title: "State-of-the-Art and Challenges for the Internet of Things Security"
-                  , href: "https://datatracker.ietf.org/doc/draft-irtf-t2trg-iot-seccons/"
-                },
                 "Geo12": {
                   authors: ["M. Georgiev", "et al."]
                   , href: "https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf"
@@ -498,7 +493,7 @@
         <li><strong>Security Provisioning:</strong> A WoT Device is provisioned with the security metadata and credentials needed
 		during its Operational state.
 		The exact set of necessary credentials will vary based on the WoT Device's deployment model and choice of security mechanisms.
-		The document <cite>The State-of-the-Art and Challenges for the Internet of Things Security</cite> [[Garcia17]]
+		The document <cite>The State-of-the-Art and Challenges for the Internet of Things Security</cite> [[RFC8576]]
 		refers to this stage as "Bootstrapping".</li>
         <li><strong>Operational:</strong> The default operational state of WoT Devices.
 		Devices in this state are fully ready to communicate over WoT interfaces and satisfy their deployment's operational roles.
@@ -1917,7 +1912,7 @@ tracking equipment, information about user's preferences in home environment, vi
     The exact set of necessary credentials
     will vary based on the WoT Device's deployment model and choice of security
     mechanisms. The document The State-of-the-Art and Challenges for the Internet
-    of Things Security [[Garcia17]] refers to this stage as "Bootstrapping".
+    of Things Security [[RFC8576]] refers to this stage as "Bootstrapping".
     </p>
 
     <p>
@@ -1987,11 +1982,9 @@ tracking equipment, information about user's preferences in home environment, vi
       Recently attempts have been made to document and categorize useful approaches to security in IoT.
       The following are some of the more useful points of reference:
       <ul>
-      <li>[[Garcia17]] - <cite>State-of-the-Art and Challenges for the Internet of Things Security</cite>:<br/>
-      This IETF document, a product of the IETF T2TRG, is still in draft form but is now a candidate for
-      ratification.
-      It covers a range of recommendations for securing IoT systems.
-      Readers should look for the latest version using the IETF RFC tracker.</li>
+      <li>[[RFC8576]] - <cite>State-of-the-Art and Challenges for the Internet of Things Security</cite>:<br/>
+      This document is a product of the ITRF T2TRG and covers a range of recommendations for securing IoT systems.
+      </li>
       <li>[[IicSF16]] - <cite>The Industrial Internet of Things Volume G4: Security Framework</cite>:<br/>
       Focuses on industrial IoT systems and use cases, and so as discussed above
       emphasizes safety over privacy considerations.

--- a/index.html
+++ b/index.html
@@ -291,13 +291,6 @@
                   , publisher: "OWASP"
                   , date: "Jan 2017"
                 },
-                "Res03": {
-                  authors: ["E. Rescorla", "et al."]
-                  , href: "https://tools.ietf.org/html/rfc3552"
-                  , title: "Guidelines for Writing RFC Text on Security Considerations"
-                  , publisher: "IETF RFC 3552 (IAB Guideline)"
-                  , date: "2003"
-                },
                 "Sch14": {
                   authors: ["B. Schneier"]
                   , href: "https://www.wired.com/2014/01/theres-no-good-way-to-patch-the-internet-of-things-and-thats-a-huge-problem/"
@@ -2063,7 +2056,7 @@ tracking equipment, information about user's preferences in home environment, vi
       These references helped define the topics covered in this document.
       <ul>
       <li>[[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite></li>
-      <li>[[Res03]] - <cite>IETF Guidelines for Writing RFC Text on Security Considerations</cite></li>
+      <li>[[RFC3552]] - <cite>IETF Guidelines for Writing RFC Text on Security Considerations</cite></li>
       </ul>
     </p><p class="ednote" title="Elaborate on additional references and/or cull">
           The references below are relevant,

--- a/index.html
+++ b/index.html
@@ -333,13 +333,6 @@
                   , date: "1999"
                   , pages: "175-185"
                 },
-                "She14": {
-                  authors: ["Z. Shelby", "et al."]
-                  , href: "https://tools.ietf.org/rfc/rfc7252.txt"
-                  , title: "The Constrained Application Protocol (CoAP)"
-                  , publisher: "IETF RFC 7252"
-                  , date: "June 2014"
-                 },
                 "Vol00": {
                   authors: ["J. Vollbrecht", "et al."]
                   , href: "https://tools.ietf.org/rfc/rfc2904.txt"
@@ -2138,7 +2131,7 @@ tracking equipment, information about user's preferences in home environment, vi
       <li>[[Oos10]] - <cite>Provisioning scenarios in identity federations</cite></li>
       <li>[[Sch14]] - <cite>The Internet of Things Is Wildly Insecure — And Often Unpatchable</cite></li>
       <li>[[Sch99]] - <cite>Breaking Up Is Hard To Do: Modeling Security Threats for Smart Cards</cite></li>
-      <li>[[She14]] - <cite>The Constrained Application Protocol (CoAP)</cite></li>
+      <li>[[RFC7252]] - <cite>The Constrained Application Protocol (CoAP)</cite></li>
       <li>[[Vol00]] - <cite>AAA Authorization Framework</cite></li>
       <li>[[Yeg11]] - <cite>Stevey's Google Platforms Rant</cite></li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -433,13 +433,6 @@
                   , publisher: "Blog"
                   , date: "Oct. 2011"
                 },
-                "Pri19": {
-                  authors: ["M. Pritikin, M. Richardson, T. Eckert,M. Behringer, K. Watsen"]
-                  , href: "https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-26"
-                  , title: "Bootstrapping Remote Secure Key Infrastructures (BRSKI)"
-                  , publisher: "IETF"
-                  , date: "Aug. 2019"
-                },
                 "SDO": {
                     href: "https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/intel-secure-device-onboard-product-brief.pdf"
                   , title: "Intel® Secure Device Onboard"
@@ -2015,7 +2008,7 @@ tracking equipment, information about user's preferences in home environment, vi
     </p>
     <section>
      <h3>Bootstrapping Remote Secure Key Infrastructures (BRSKI)</h3>
-        The draft IETF standard [[Pri19]]
+        The proposed IETF standard [[RFC8995]]
     </section>
     <section>
      <h3>Intel Secure Device Onboard (SDO)</h3>

--- a/index.html
+++ b/index.html
@@ -96,13 +96,6 @@
                   , date: "2014"
                   , pages: "114-129"
                 },
-                "Lea05": {
-                  authors: ["P. Leach", "et al"]
-                  , href: "https://tools.ietf.org/html/rfc4122"
-                  , title: "A Universally Unique IDentifier (UUID) URN Namespace"
-                  , publisher: "IETF RFC 4122"
-                  , date: "July 2005"
-                },
                 "Dur13": {
                   authors: ["Z. Durumeric", "et al."]
                   , href: "https://conferences.sigcomm.org/imc/2013/papers/imc257-durumericAemb.pdf"
@@ -1867,7 +1860,7 @@ tracking equipment, information about user's preferences in home environment, vi
                       is not specified how such identifier should be generated and the duration of its
 		      validity.
                       Typically such identifiers are generated using various methods outlined in
-                      [[Lea05]] - <cite>A Universally Unique IDentifier (UUID) URN Namespace</cite>.
+                      [[RFC4122]] - <cite>A Universally Unique IDentifier (UUID) URN Namespace</cite>.
                       If this identifier is a persistent unique identifier that is never changed during device
                       lifecycle (immutable) or changed very rarely (for example only when a WoT System is
                       installed and bootstrapped), then a WoT Device and a WoT <a>System User</a> might

--- a/index.html
+++ b/index.html
@@ -116,13 +116,6 @@
                   , date: "2014"
                   , pages: "114-129"
                 },
-                "Coo13": {
-                  authors: ["A. Cooper", "et al"]
-                  , href: "https://tools.ietf.org/html/rfc6973"
-                  , title: "Privacy Considerations for Internet Protocols"
-                  , publisher: "IETF RFC 6973 (IAB Guideline)"
-                  , date: "July 2013"
-                },
                 "Lea05": {
                   authors: ["P. Leach", "et al"]
                   , href: "https://tools.ietf.org/html/rfc4122"
@@ -1842,7 +1835,7 @@ tracking equipment, information about user's preferences in home environment, vi
                       This recommendation corresponds to the data minimization
                       and security (unauthorized usage, peer entity authentication and confidentiality)
                       treat mitigation strategies outlined in
-		      [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>.
+		      [[RFC6973]] - <cite>Privacy Considerations for Internet Protocols</cite>.
                       </td>
                 </tr>
                 <tr>
@@ -1867,7 +1860,7 @@ tracking equipment, information about user's preferences in home environment, vi
                       This recommendation corresponds to the data minimization
                       and security (unauthorized usage, peer entity authentication and confidentiality)
                       treat mitigation strategies outlined in
-                      [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>. </td>
+                      [[RFC6973]] - <cite>Privacy Considerations for Internet Protocols</cite>. </td>
                 </tr>
                 <tr>
                  <td><dfn>Leaking WoT System User Data</dfn></td>
@@ -1886,7 +1879,7 @@ tracking equipment, information about user's preferences in home environment, vi
 		      This recommendation
                       corresponds to the data minimization and security (inappropriate usage,
                       unauthorized usage and confidentiality) treat mitigation strategies outlined in
-                      [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>.</td>
+                      [[RFC6973]] - <cite>Privacy Considerations for Internet Protocols</cite>.</td>
                 </tr>
                 <tr>
                  <td><dfn>Tracking WoT System User</dfn></td>
@@ -1924,7 +1917,7 @@ tracking equipment, information about user's preferences in home environment, vi
              a way for <a>System Users</a> to control the degree of such exposure.
 	     This recommendation
              corresponds to the user participation in treat mitigation strategy outlined in
-             [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>.
+             [[RFC6973]] - <cite>Privacy Considerations for Internet Protocols</cite>.
             </p>
 
           <p class="ednote" title="Links">
@@ -2055,7 +2048,7 @@ tracking equipment, information about user's preferences in home environment, vi
       that should be included in internet standards.
       These references helped define the topics covered in this document.
       <ul>
-      <li>[[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite></li>
+      <li>[[RFC6973]] - <cite>Privacy Considerations for Internet Protocols</cite></li>
       <li>[[RFC3552]] - <cite>IETF Guidelines for Writing RFC Text on Security Considerations</cite></li>
       </ul>
     </p><p class="ednote" title="Elaborate on additional references and/or cull">

--- a/index.html
+++ b/index.html
@@ -112,12 +112,6 @@
                 , publisher: "IETF"
                 , date: "July 2017"
                 },
-                "COSE17": {
-                  href: "https://tools.ietf.org/html/rfc8152"
-                , title: "CBOR Object Signing and Encryption (COSE)"
-                , publisher: "IETF"
-                , date: "May 2017"
-                },
                 "Bel89": {
                   authors: ["S. Bellovin"]
                 , href: "https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf"
@@ -2418,10 +2412,10 @@ tracking equipment, information about user's preferences in home environment, vi
 		     MACs are created by the producers/issuers of the objects and validated by consumers of the objects
 		     (which should reject signed the objects whose signatures/MACs are invalid). For data expressed in
 		     JSON, [[JWS15]] provides a guideline for expressing digital signatures or MACs as well as related
-		     security metadata using JSON-based data structures. [[COSE17]] does the same for CBOR.</li>
+		     security metadata using JSON-based data structures. [[RFC9052]] does the same for CBOR.</li>
                  <li>If confidentiality is desired for exchanged application data, then encrypt WoT objects using well-known
 		     encryption primitives. For data expressed in JSON, [[JWE15]] provides a guideline for expressing
-	             encrypted data as well as related security metadata using JSON-based data structures. [[COSE17] does
+	             encrypted data as well as related security metadata using JSON-based data structures. [[RFC9052]] does
 	             the same for CBOR. Moreover the following is important here:
 		     <ul>
                          <li>Confidentiality without authenticity (i.e. encryption-only) does not provide a secure scheme.
@@ -2614,7 +2608,7 @@ tracking equipment, information about user's preferences in home environment, vi
             Thing Descriptions to the WoT Consumer or in case the remote cloud is not a trusted entity,
 	    the authenticity of the Thing Description should be verified using other methods on the application layer,
             such as wrapping the Thing Description into a protected
-	    CBOR Object Encryption and Signing (COSE) object [[COSE17]].
+	    CBOR Object Encryption and Signing (COSE) object [[RFC9052]].
             This can be done by the provider of the Thing Description and verified by the
 	    WoT Consumer after the download from the remote cloud.
             </p>
@@ -2817,7 +2811,7 @@ tracking equipment, information about user's preferences in home environment, vi
            tunnel configuration.  In particular, unencrypted traffic is available both locally (on the local network
            and/or inside the gateway) and in the cloud portal.  Therefore both the gateway and the cloud portal
            need to be trusted.  This can be mitigated somewhat by using application-level end-to-end object security
-           [[COSE17]].
+           [[RFC9052]].
            </p>
 
             <figure id="wot_client_thing_proxy">
@@ -2860,7 +2854,7 @@ HTTPS)/HTTP Proxy</figcaption>
            as a separate service.  Conceptually the functions are distinct. -->
            </p>
            <p>In both of these sub-patterns, object security (that is, encryption and authentication of payloads
-	   at the application level) can be used to preserve confidentiality and integrity if necessary [[COSE17]].
+	   at the application level) can be used to preserve confidentiality and integrity if necessary [[RFC9052]].
 	   A caching proxy can
 	   simply store and return copies of the encrypted data representing the state of "private" properties.
            </p>

--- a/index.html
+++ b/index.html
@@ -122,21 +122,21 @@
                   authors: ["S. Bellovin"]
                 , href: "https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf"
                 , title: "Security Problems in the TCP-IP Protocol Suite"
-                , publisher: "Computer Communication Review, Vol. 19, No. 2" 
+                , publisher: "Computer Communication Review, Vol. 19, No. 2"
                 , pages: "32-48"
                 , date: "April 1989"
                 },
                 "Bel13": {
                   authors: ["S. Bellovin"]
 	          , href: "https://csrc.nist.gov/csrc/media/events/workshop-on-improving-trust-in-the-online-marketpl/documents/presentations/bellovin_ca-workshop2013.pdf"
-                  , title: "Web Security in the Real World" 
-                  , publisher: "Workshop on Improving Trust in the Online Marketplace, NIST" 
+                  , title: "Web Security in the Real World"
+                  , publisher: "Workshop on Improving Trust in the Online Marketplace, NIST"
                   , date: "April 2013"
                 },
                 "Ber14": {
                   authors: ["V. Bertocci"]
                   , href: "http://www.cloudidentity.com/blog/2014/04/22/authentication-protocols-web-ux-and-web-api/"
-                  , title: "Authentication Protocols, Web UX and Web API" 
+                  , title: "Authentication Protocols, Web UX and Web API"
                   , date: "April 2014"
                 },
                 "Bor14": {
@@ -210,7 +210,7 @@
                   , publisher: "Distributed Computing, vol. 16"
                   , pages: "177-199"
                   , date: "2003"
-                }, 
+                },
                 "Gre14": {
                   authors: ["M. Green"]
                   , href: "https://blog.cryptographyengineering.com/2014/03/19/how-do-you-know-if-rng-is-working/"
@@ -311,7 +311,7 @@
                   , date: "2002"
                 },
                 "Nis15": {
-                  authors: ["NIST"] 
+                  authors: ["NIST"]
                   , title: "Guide to Industrial Control Systems (ICS) Security"
                   , publisher: "NIST Special Publication 800-82"
                 },
@@ -319,7 +319,7 @@
                   authors: ["M. Oosdijk", "et al."]
                   , href: "https://tnc2011.terena.org/getfile/696"
                   , title: "Provisioning scenarios in identity federations"
-                  , publisher: "Surfnet Research Paper" 
+                  , publisher: "Surfnet Research Paper"
                   , date: "2010"
                 },
                 "Owa17": {
@@ -523,7 +523,7 @@
      All recommendations are linked to the corresponding WoT threats in the generic woT threat model in order to
      facilitate understanding of why they are needed.
      </p><p>
-     It is not the intention of this document to limit the set of security mechanisms that can be used to 
+     It is not the intention of this document to limit the set of security mechanisms that can be used to
      secure a WoT System.
      In particular, while we provide examples and recommendations based on the best available practices in the industry,
      this document contains informative statements only.
@@ -531,9 +531,9 @@
      for each WoT building block.
      </p>
      <p class="ednote">
-        This content should be consistent with the summaries in the 
+        This content should be consistent with the summaries in the
         Security sections of other WoT documents, in particular the
-	[[WoT-Architecture]] and [[WoT-Thing-Description]] 
+	[[WoT-Architecture]] and [[WoT-Thing-Description]]
         documents.
      </p>
     </section>
@@ -546,22 +546,22 @@
 
     <section>
       <h1>Introduction</h1>
-      <p>Security of a WoT System can refer to the security of the Thing Description (TD) itself or 
+      <p>Security of a WoT System can refer to the security of the Thing Description (TD) itself or
       the security of the Thing the Thing Description describes.
     <section>
       <h2>Related W3C Documents</h2>
       <p>
-        For a general discussion of best practices for developing secure WoT Systems, 
+        For a general discussion of best practices for developing secure WoT Systems,
         as well as a set of suggested combinations of authentication mechanisms
         and secured protocols,
-        see the <a href="https://github.com/w3c/wot-security-best-practices/">WoT 
+        see the <a href="https://github.com/w3c/wot-security-best-practices/">WoT
         Security Best Practices</a> document.
       </p>
       <p>For details on the Web of Things architecture, please refer to the following:
       <ul>
         <li>the <a href="https://www.w3.org/WoT/IG/">Interest Group</a> web site</li>
         <li>the <a href="https://www.w3.org/WoT/WG/">Working Group</a> web site</li>
-        <li>the [[WoT-Architecture]] document,</li> 
+        <li>the [[WoT-Architecture]] document,</li>
         <li>the [[WoT-Thing-Description]] document,</li>
         <li>the [[WoT-Binding-Templates]] document, and</li>
         <li>the [[WoT-Scripting-API]] document.</li>
@@ -583,41 +583,41 @@
       <p>The lifecycle of a WoT Device is similar to the lifecycles of other IoT devices and services.
       It may in fact be identical if a WoT Thing Description is being used simply to describe an existing device
       implemented using another standard.
-      However, 
-      for discussion purposes we will use the generic lifecycle shown in <a href="#wot-lifecycle"></a> 
+      However,
+      for discussion purposes we will use the generic lifecycle shown in <a href="#wot-lifecycle"></a>
       which includes the following states:
       <ul>
         <li><strong>Manufactured:</strong> The WoT Device has been manufactured by an OEM.
-		It might have a WoT runtime present that enables single or multi-tenant users 
+		It might have a WoT runtime present that enables single or multi-tenant users
                 or it might only have network interfaces exposed present that are compatible with a WoT description.
-		From the Manufactured state, based on the deployment scenario, the device can transition to either of two states: 
+		From the Manufactured state, based on the deployment scenario, the device can transition to either of two states:
 		the Installation/Commissioning state or the Security Provisioning state.</li>
         <li><strong>Installation/Commissioning:</strong> A WoT Device has been installed into its intended deployment environment
-		by a system provider or system integrator and any necessary SW configuration has been performed. 
+		by a system provider or system integrator and any necessary SW configuration has been performed.
 		In practice this state may be combined with or reordered with the Security Provisioning state.</li>
-        <li><strong>Security Provisioning:</strong> A WoT Device is provisioned with the security metadata and credentials needed 
-		during its Operational state. 
-		The exact set of necessary credentials will vary based on the WoT Device's deployment model and choice of security mechanisms. 
-		The document <cite>The State-of-the-Art and Challenges for the Internet of Things Security</cite> [[Garcia17]] 
+        <li><strong>Security Provisioning:</strong> A WoT Device is provisioned with the security metadata and credentials needed
+		during its Operational state.
+		The exact set of necessary credentials will vary based on the WoT Device's deployment model and choice of security mechanisms.
+		The document <cite>The State-of-the-Art and Challenges for the Internet of Things Security</cite> [[Garcia17]]
 		refers to this stage as "Bootstrapping".</li>
-        <li><strong>Operational:</strong> The default operational state of WoT Devices. 
-		Devices in this state are fully ready to communicate over WoT interfaces and satisfy their deployment's operational roles. 
-		From the Operational state a device can return to the Manufactured state 
-                if it is fully decommissioned and security de-provisioned 
-		(link E in <a href="#wot-lifecycle"></a>). 
+        <li><strong>Operational:</strong> The default operational state of WoT Devices.
+		Devices in this state are fully ready to communicate over WoT interfaces and satisfy their deployment's operational roles.
+		From the Operational state a device can return to the Manufactured state
+                if it is fully decommissioned and security de-provisioned
+		(link E in <a href="#wot-lifecycle"></a>).
 		It is also possible to perform only a partial reset of a device,
-		if it only requires re-installation and recommissioning without security re-provisioning 
+		if it only requires re-installation and recommissioning without security re-provisioning
 		(link D in <a href="#wot-lifecycle"></a>).
-		It is also possible that only security re-provisioning is needed 
+		It is also possible that only security re-provisioning is needed
                 without re-installation and re-commissioning (link C in <a href="#wot-lifecycle"></a>).</li>
-        <li><strong>Maintenance and Security Update:</strong> 
+        <li><strong>Maintenance and Security Update:</strong>
                 A state that is entered when the device's software or configuration needs to be updated.
-	        This is an optional state that can be activated remotely or locally (link A in <a href="#wot-lifecycle"></a>) 
-		on a WoT Device depending on the deployment model and overall setup. 
+	        This is an optional state that can be activated remotely or locally (link A in <a href="#wot-lifecycle"></a>)
+		on a WoT Device depending on the deployment model and overall setup.
 		This state can be required to maintain security,
-                for example to patch SW vulnerabilities or perform security-related configuration updates, 
-		such as key revocation or certificate refresh. 
-		After maintenance or updates are done, 
+                for example to patch SW vulnerabilities or perform security-related configuration updates,
+		such as key revocation or certificate refresh.
+		After maintenance or updates are done,
 		the device normally returns to the Operational state (link B in <a href="#wot-lifecycle"></a>). </li>
       </ul>
       The scope of this document only covers the Security Provisioning, Operational and Maintenance and Security
@@ -627,12 +627,12 @@
 
   <section>
     <h1>Requirements</h1>
-	
+
         <section>
         <h2>General</h2>
             <p>
             In general using the WoT approach should "do no harm": the security of any protocols should be maintained.
-            The Web of Things does not introduce new security mechanisms, 
+            The Web of Things does not introduce new security mechanisms,
             but should preserve the functionality and security of existing mechanisms.
             We also have the following requirements:
             <ul>
@@ -643,7 +643,7 @@
                 <li><strong>Consuming:</strong>
 		A consumed TD should accurately reflect the actual security status of the device it describes.</li>
                 <li><strong>Protocols:</strong>
-                The WoT can potentially apply to many protocols but to limit scope in this 
+                The WoT can potentially apply to many protocols but to limit scope in this
                 discussion we will focus on the needs of HTTP(S), CoAP(S), and MQTT(S).</li>
             </ul>
             </p>
@@ -651,8 +651,8 @@
 
         <section id="wot-threat-model">
         <h2>Threat Model</h2>
-            <p> 
-              Due to the large diversity of devices, use cases, 
+            <p>
+              Due to the large diversity of devices, use cases,
 	      deployment scenarios and requirements for WoT Things,
               it is impossible to define a single WoT threat model that would fit every case.
               Instead we describe here an overall WoT threat model framework that can be adjusted
@@ -665,8 +665,8 @@
             criteria that might increase the risk level for a particular WoT architecture, such as handing
             privacy-sensitive data, physical safety of individuals or the surrounding environment, high
             availability requirements, and so forth.
-            In addition threat mitigations will always be limited by the capabilities of underlying 
-            devices, their list of supported security protocols, processes isolation capabilities, etc. 
+            In addition threat mitigations will always be limited by the capabilities of underlying
+            devices, their list of supported security protocols, processes isolation capabilities, etc.
             </p>
 
  <section id="wot-threat-model-stakeholders">
@@ -682,8 +682,8 @@
 			<th><dfn data-lt="device manufacturer|device manufacturers|manufacturer|oem">
                             Device Manufacturer</dfn> (OEM)</th>
 			<td>
-      Producer of the HW device. 
-      Implements the WoT runtime on the device, 
+      Producer of the HW device.
+      Implements the WoT runtime on the device,
       defines Things that the device provides, and generates TDs for these Things.</td>
       <td>
       Don't want the devices they make to be used in any form of attack
@@ -723,18 +723,18 @@
       </td>
       <td>
       There might be several independent system providers (tenants) on a single HW device.
-      In that case isolation between them is required while (perhaps) sharing 
+      In that case isolation between them is required while (perhaps) sharing
       user preferences and identification.
       </td>
       </tr><tr>
       <th><dfn data-lt="system user|system users">System User</dfn></th>
       <td>
       These might be physical users (e.g. John and his family in their smart home)
-      or abstract users (e.g. the company running a factory). 
-      The primary characteristic of this stakeholder is the need to use 
-      the WoT System to obtain some functionality. 
-      System Users entrust WoT Systems with their data 
-      (video streams from home cameras or factory plans) or physical capabilities 
+      or abstract users (e.g. the company running a factory).
+      The primary characteristic of this stakeholder is the need to use
+      the WoT System to obtain some functionality.
+      System Users entrust WoT Systems with their data
+      (video streams from home cameras or factory plans) or physical capabilities
       in the surrounding environment (put lights on in a room or start a machine on the factory line).
       They might differ in their access to the WoT System
       and transferred data (for example, they might only be able to configure
@@ -746,7 +746,7 @@
       <a>System Provider</a> or <a>OEM</a> unless intended (Data Confidentiality).
       Don't want their data to be modified unless intended (Data Integrity).</td>
       <td>Access to user data might be configurable based not only on "who"
-      is the entity accessing the data (access control subject), 
+      is the entity accessing the data (access control subject),
       but also his/her/its role,
       type of access, or time and context.</td>
       </tr><tr>
@@ -775,14 +775,14 @@
       </td>
       <td>
       Needs to have enough access to the WoT System to perform its duties.
-      Should have minimal (ideally none) access to the data of other stakeholders.  
+      Should have minimal (ideally none) access to the data of other stakeholders.
       </td>
       <td></td>
       </tr>
       </table>
     </section>
 
-       
+
 
     <section id="wot-threat-model-assets">
     <h3>Assets</h3>
@@ -796,13 +796,13 @@
          </tr><tr>
             <th><dfn data-lt="thing descriptions|td|tds">
                  Thing Description</dfn> (TD)</th>
-            <td>Access Control policies for TDs and the resources it describes are part of TDs. 
-            They are managed using a discretionary access control model 
+            <td>Access Control policies for TDs and the resources it describes are part of TDs.
+            They are managed using a discretionary access control model
             (the owner of a TD sets the AC policy).
             Some contents of TDs might be privacy sensitive and therefore should not be shared without a specific need.
             The integrity of TDs is crucial for the correct operation of a WoT System.
             </td>
-                 <td>TD owner: full access<br/> 
+                 <td>TD owner: full access<br/>
                      Others: read only for minimal required part.</td>
                  <td>Storage on thing itself, cloud storage, in-transfer (network) including TD updates.</td>
          </tr><tr>
@@ -812,7 +812,7 @@
                video/audio streams, etc.  Can be highly privacy sensitive and confidential.</td>
             <td>Different <a>System Users</a> might have different levels of
             access to this data based on the use case. In some cases (like user preferences or settings)
-            the partial access to this asset is also needed by a <a>System Provider</a>. 
+            the partial access to this asset is also needed by a <a>System Provider</a>.
             Non-authorized access must be minimized since access even to a small amount of information
             (for example the last timestamp when a door lock API was used) might have severe
             privacy concerns (this example would allow an attacker to detect when the owner is away
@@ -828,11 +828,11 @@
             <a>System Provider</a>. It also includes Exposed Things, i.e.
             run-time representations of scripts running inside a WoT Runtime.
             <a>System providers</a> might have Intellectual Property (IP) in their scripts,
-            making them highly confidential. 
-            Protocol Bindings might be part of System Provider Data, 
-            if a WoT Device has a single System Provider that 
-            installs and configures WoT Runtime and Protocol Bindings. 
-            However, these can be also provided and confgured by the OEM, 
+            making them highly confidential.
+            Protocol Bindings might be part of System Provider Data,
+            if a WoT Device has a single System Provider that
+            installs and configures WoT Runtime and Protocol Bindings.
+            However, these can be also provided and confgured by the OEM,
             and the same Protocol Bindings could be used by
             multiple System Providers on the same device. </td>
             <td><a>System Provider</a>: full access<br/>
@@ -847,7 +847,7 @@
                      WoT Infrastructure Resources</dfn></th>
             <td>Resources should only be used for legitimate purposes and be available when required.</td>
             <td><a>System User</a>, <a>System Provider</a></td>
-            <!-- TODO: "WoT Interface" is a term for the network API of a Thing 
+            <!-- TODO: "WoT Interface" is a term for the network API of a Thing
             defined in the WoT architecture document. How do we refer to these,
             and can we link to their definitions? -->
             <td>WoT Interface</td>
@@ -861,17 +861,17 @@
             <td>WoT Interface</td>
           </tr><tr>
             <th><dfn>WoT Behavior Metrics</dfn></th>
-            <td>Indirectly transmitted information (metadata) that represents measurements of 
-            a WoT System's behavior from which other information can be inferred, such as user presence. 
+            <td>Indirectly transmitted information (metadata) that represents measurements of
+            a WoT System's behavior from which other information can be inferred, such as user presence.
             For example, the amount of communication between different things,
             the APIs used, distribution of communication over time, etc.</td>
             <td>It should not be possible to collect/identify indirectly transferable information</td>
             <td>In-transfer data and usage of WoT Interface</td>
           </tr><tr>
             <th><dfn>WoT Basic Security Metadata</dfn></th>
-            <td>All required security metadata (keys, certificates etc.) that might be provisioned 
-            to the WoT Device in order to be able to perform various security-related operations, 
-            such as authenticating another device or WoT Consumer in the WoT System, 
+            <td>All required security metadata (keys, certificates etc.) that might be provisioned
+            to the WoT Device in order to be able to perform various security-related operations,
+            such as authenticating another device or WoT Consumer in the WoT System,
             authenticating remote authorization service in case the access control to WoT interfaces is done using tokens, etc.</td>
             <td> Manager Thing (if present in WoT Runtime) - an entity that can implement script lifecycle management operations, WoT Runtime </td>
             <td> On device storage, in-transfer including provisioning and updates of security metadata.
@@ -912,8 +912,8 @@
               </tr><tr>
                   <th><dfn>WoT Runtime Isolation Policies</dfn></th>
                   <td>Access control policies for isolating co-existing system providers on the device.
-                      Not required if a simple baseline policy of "full isolation" is applied 
-                      to different WoT Runtimes running scripts from different System providers. 
+                      Not required if a simple baseline policy of "full isolation" is applied
+                      to different WoT Runtimes running scripts from different System providers.
                       It might be required if some level of data sharing between them is needed. </td>
                   <td><a>System Provider</a>, <a>System Maintainer</a></td>
                   <td>Storage on the thing itself, remote storage (if they are backed up to a remote storage),
@@ -935,9 +935,9 @@
                   <td>Unauthorized access or modification of any stakeholder's asset over the network.
                       Denial of service. Inferring of non-public or privacy sensitive information.
                       Taking control of the network component of a WoT System. Reasons: money, fame etc.</td>
-                  <td>Network attack: an attacker has network access to a WoT System, 
-                      is able to use WoT Interface, perform Man-in-the-Middle (MitM) attacks, 
-                      drop, delay, reorder, re-play, and inject messages. 
+                  <td>Network attack: an attacker has network access to a WoT System,
+                      is able to use WoT Interface, perform Man-in-the-Middle (MitM) attacks,
+                      drop, delay, reorder, re-play, and inject messages.
                       This attacker type also includes a passive network attacker, where an attacker is only able to passively
                       observe the WoT System traffic.</td>
               </tr><tr>
@@ -999,7 +999,7 @@
                </tr><tr>
 		   <th><dfn>Malicious OEM</dfn></th>
 		   <td>Intentionally installs HW, firmware or other lower SW level backdoors,
-		       rootkits etc. 
+		       rootkits etc.
 		       in order to get unauthorized access to WoT assets or affect WoT System in any form</td>
 		   <td>Local physical access, privileged access</td>
 	       </tr><tr>
@@ -1025,11 +1025,11 @@
        <section id="wot-threat-model-attack-surfaces">
        <h3 id="e-wot-threat-model-attack-surfaces">Attack Surfaces</h3>
            <p>In order to correctly define WoT attack surfaces one needs to determine the system's
-              trust model as well as execution context boundaries. 
+              trust model as well as execution context boundaries.
               A high-level view of the WoT architecture from the security point of view is presented in
               <a href="#wot-security-fig-attack-surfaces"></a>,
               showing all possible execution boundaries.
-              However, in practice certain execution boundaries might not be present as they are 
+              However, in practice certain execution boundaries might not be present as they are
               dependent on the actual device implementation.</p>
 
            <figure id="wot-security-fig-attack-surfaces">
@@ -1051,10 +1051,10 @@
                    <td>Separates execution contexts between different Exposed Things.
                        If present,
                        this boundary should be implemented either as having different script runtime
-                       contexts (with WoT runtime isolation means) 
+                       contexts (with WoT runtime isolation means)
                        or by having separate process execution contexts
                        (with OS process isolation means)</td>
-                   <td>This boundary is required if we assume that WoT Runtime can run untrusted scripts 
+                   <td>This boundary is required if we assume that WoT Runtime can run untrusted scripts
                    or if some scripts have a higher chance of being compromised remotely</td>
                </tr><tr>
                    <th><dfn>WoT Runtime Instance Execution Boundary</dfn></th>
@@ -1064,7 +1064,7 @@
                        but in addition can be implemented using any stronger security measures available
                        on the device (Mandatory Access Control, OS-kernel level virtualization,
                        Full Virtualization etc.)</td>
-                   <td>This boundary is required if we assume that we have different <a>System Providers</a> 
+                   <td>This boundary is required if we assume that we have different <a>System Providers</a>
                        running on the same device in different WoT Runtime Instances.</td>
                </tr><tr>
                    <th><dfn>WoT Execution Boundary</dfn></th>
@@ -1131,9 +1131,9 @@
            layer and the rest of the software on a given physical device, we don't consider it
            as in-scope attack surface for this threat model, because we are not able to define
            security measures that prevent lower layers of device's software stack to access
-           and compromise the WoT runtime and Protocol Bindings. Such measures would greatly 
+           and compromise the WoT runtime and Protocol Bindings. Such measures would greatly
            depend on underlying device implementation and should be considered by an OEM that
-           produces physical device and enables it for WoT usage. Similar the <a>WoT Runtime 
+           produces physical device and enables it for WoT usage. Similar the <a>WoT Runtime
            and Protocol Bindings Execution Boundaries</a>are out of scope, because their presence
            and implementation depends on concrete architecture of WoT runtime.</p>
 
@@ -1183,7 +1183,7 @@
                </tr><tr>
                    <th>WoT Script Management Interface. This interface, likely in practice
                    implemented by a manager Thing (or Thing Manager), allows dynamic installation,
-                   removal and update of WoT scripts. 
+                   removal and update of WoT scripts.
                 </th>
                    <td>Compromise of WoT scripts,
                        including installing an older version of legitimate scripts (rollback)</td>
@@ -1235,11 +1235,11 @@
                    type of DoS attack on <a>WoT Thing Resources</a> or <a>WoT
                    Infrastructure Resources</a></td>
                    <td>This attack surface is out of scope because WoT specifications do
-                   not cover non-WoT endpoints. 
+                   not cover non-WoT endpoints.
 		   <!--
 		   However, <a href="#sec-pract-non-wot-endpoints"></a>
                    lists generic recommendations and best known security practices that
-                   should be followed when designing non-WoT endpoints. 
+                   should be followed when designing non-WoT endpoints.
 		   -->
 		   </td>
                </tr><tr>
@@ -1252,14 +1252,14 @@
                    of DoS attack on <a>WoT Thing Resources</a> or <a>WoT Infrastructure
                    Resources</a></td>
                    <td>This attack surface is out of scope because WoT specifications do
-                   not cover levels below the WoT Runtime. 
+                   not cover levels below the WoT Runtime.
 		   <!-- However,
                    <a href="#sec-pract-below-wot-runtime"></a> lists generic
                    recommendations and best known security practices that should be
                    followed when designing the levels below WoT Runtime. In addition
                    <a href="#sec-pract-end-to-end-security"></a> discusses methods
                    to provide end-to-end security between WoT endpoints in case an intermediate
-                   node, such as a Intermediary WoT Servient, is compromised. 
+                   node, such as a Intermediary WoT Servient, is compromised.
 		   -->
 		   </td>
                </tr>
@@ -1292,11 +1292,11 @@
                    <a>Malicious Users</a></td>
                <td>All WoT assets within the same execution boundary</td>
                <td><strong>Pre-conditions:</strong>
-                   General preconditions for a network attacker with access to 
+                   General preconditions for a network attacker with access to
 		   the WoT Protocol Bindings and/or WoT Interface.
                    In case of <a>Malicious Authorized Solution User</a>
                    or <a>Malware Developer</a>
-                   also access to solution user credentials available on the configuration interface 
+                   also access to solution user credentials available on the configuration interface
                    (smartphone, tablet etc.)<br/>
                    <strong>Attack method:</strong>
                    Any remote attack method using WoT Interface or directly
@@ -1311,7 +1311,7 @@
                <td><strong>Pre-conditions:</strong>
                    Same as for <a>WoT Protocol Binding Threat</a>
                    <strong>Attack method</strong>:
-                   Same as for <a>WoT Protocol Binding Threat</a> with 
+                   Same as for <a>WoT Protocol Binding Threat</a> with
 		   the purpose of compromising an Exposed Thing.</td>
            </tr><tr>
                <th><dfn>WoT Interface Threat - Unauthorized WoT Interface Access</dfn></th>
@@ -1339,10 +1339,10 @@
                <td><strong>Pre-conditions:</strong>
                    General preconditions for an attacker with access to a WoT Interface<br/>
                    <strong>Attack method:</strong>
-                   Any attack method using a WoT Interface in order to 
+                   Any attack method using a WoT Interface in order to
 		   cause Denial-of-Service (DoS) to an end thing,
                    device, service, or infrastructure
-                   (calling WoT Interface methods that require excessive processing, 
+                   (calling WoT Interface methods that require excessive processing,
 		   sending too many messages etc.)
                    or to disturb the service operation by intentional dropping
                    of all or selective WoT messages</td>
@@ -1404,13 +1404,13 @@
                  <td><strong>Pre-conditions:</strong>
                      General preconditions for network attacker with access to a WoT Interface<br/>
                      <strong>Attack method:</strong>
-                     Passive observation of WoT System and messages with the intention to learn 
+                     Passive observation of WoT System and messages with the intention to learn
                      behavioral and operational patterns</td>
              </tr>
          </table>
 
          <p class="ednote" title="Policy management threats to be added">
-             We may need to add threats related to credentials/policy management 
+             We may need to add threats related to credentials/policy management
 	     depending on how they are exposed/stored within WoT runtime via scripting.
 	     However, currently WoT scripting is (intentionally) not able to access or manage credentials;
 	     instead they must be installed using a separate management interface
@@ -1430,7 +1430,7 @@
                  <td><a>Network Attacker</a>,
                      <a>Malware Developer</a>,
                      <a>Malicious Users</td>
-                 <td>Execution inside WoT Runtime (stepping stone to other further local attacks) 
+                 <td>Execution inside WoT Runtime (stepping stone to other further local attacks)
                      and all assets within WoT Runtime</td>
                  <td><strong>Pre-conditions:</strong>
                      General preconditions for network attacker with access to a WoT Script Management API<br>
@@ -1441,7 +1441,7 @@
                  <td><a>Network Attacker</a>,
                      <a>Malware Developer</a>,
                      <a>Malicious Users</td>
-                 <td>Compromise of WoT Runtime itself (stepping stone to other further local attacks) 
+                 <td>Compromise of WoT Runtime itself (stepping stone to other further local attacks)
 			 and all assets within WoT Runtime</td>
                  <td><strong>Pre-conditions:</strong>
                      General preconditions for network attacker with access to the WoT Script Management API<br/>
@@ -1462,8 +1462,8 @@
          </table>
 
          <p>The general term <dfn>WoT Script Management Interface Threat</dfn> may be used to refer to any or all of
-             <a>WoT Script Management Interface Threat - Script installation</a>, 
-             <a>WoT Script Management Interface Threat - WoT Runtime Compromise</a>, or 
+             <a>WoT Script Management Interface Threat - Script installation</a>,
+             <a>WoT Script Management Interface Threat - WoT Runtime Compromise</a>, or
              <a>WoT Script Management Interface Threat - DoS</a>.</p>
 
          <p>If a WoT System allows co-existence of different independent <a>System Providers</a> (tenants) on a
@@ -1483,7 +1483,7 @@
                <td>Component compromise and all WoT assets within the same execution boundary</td>
                <td><strong>Pre-conditions:</strong>
                    An attacker has full control over a script running inside a WoT runtime either
-                   legitimately (<a>System Provider Script</a>) 
+                   legitimately (<a>System Provider Script</a>)
 		   or by compromising a <a>System Provider Script</a> or
                    by installing their own script by other means.<br/>
                    <strong>Attack method:</strong>
@@ -1533,7 +1533,7 @@
                     Same as for <a>WoT Untrusted Script Threat - Script Compromise</a><br/>
                       <strong>Attack method:</strong>
                       Any local attack method on another script running in the same WoT runtime that results
-                      in an attacker obtaining unauthorized access 
+                      in an attacker obtaining unauthorized access
                       to non-public parts of <a>TDs</a> or privacy sensitive parts of <a>TDs</a>.</td>
               </tr><tr>
                   <th><dfn>WoT Untrusted Script Threat - TD Authenticity</dfn></th>
@@ -1578,7 +1578,7 @@
                   <td><a>WoT Thing Resources</a>,<a>WoT Infrastructure Resources</a>of another <a>system provider</a></td>
                   <td><strong>Pre-conditions:</strong>
                     Same as for <a>WoT Untrusted Script Threat - Script Compromise</a><br/>
-                      <strong>Attack method:</strong> 
+                      <strong>Attack method:</strong>
                       Any local attack method with the goal of consuming things or infrastructure resources
                       that disturb legitimate operation of co-existing <a>System Providers</a>.</td>
               </tr>
@@ -1590,7 +1590,7 @@
  <h2>Security Scenarios</h2>
   <p>
     Here we describe some typical high-level WoT scenarios and give practical examples of the above threats
-    for each scenario.   
+    for each scenario.
   </p>
 
 <section>
@@ -1598,10 +1598,10 @@
 
 <p>In this scenario we assume a standard home environment with a WoT System running behind a firewall NAT that
  separates it from the rest of the Internet. However the WoT System is shared with the standard user home
- network that contains other non-WoT Devices that have high chances of being compromised. 
- This results in viewing these non-WoT Devices as possible network attackers 
+ network that contains other non-WoT Devices that have high chances of being compromised.
+ This results in viewing these non-WoT Devices as possible network attackers
  with access to the WoT System and its APIs/Protocol Bindings.
- Other assumptions: 
+ Other assumptions:
  WoT scripts and protocol bindings are considered trusted; a single <a>System Provider</a> exists on physical
  WoT Devices; and no dynamic installation of WoT scripts is possible.</p>
 
@@ -1615,7 +1615,7 @@
 <tr>
 <td><a>WoT Protocol Binding Threat</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT Devices sends
-a malformed request to a WoT Device targeting the Protocol Bindings interface directly. 
+a malformed request to a WoT Device targeting the Protocol Bindings interface directly.
 This malformed request causes
 the respective Protocol Binding to be compromised (e.g. by exploiting a buffer-overflow bug)
 and the attacker is able to run code with the privileges of
@@ -1624,16 +1624,16 @@ the Protocol Binding on the WoT Device.</td>
 <tr>
 <td><a>WoT Interface Threat - Exposed Thing Compromise</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT Devices sends
- a malformed request to a WoT Device using the WoT interface. This malformed request causes the respective 
+ a malformed request to a WoT Device using the WoT interface. This malformed request causes the respective
  Exposed Thing to be compromised and attacker is able to run code with the privileges of the Exposed Thing on
  the WoT Device.</td>
 </tr>
 <tr>
 <td><a>WoT Interface Threat - Unauthorized WoT Interface Access</a></td>
 <td>A user's party guest with network access to the same internal network as WoT Devices uses his device
- to send a WoT interface request to a user's WoT Device for a certain resource access, for example, to get a 
+ to send a WoT interface request to a user's WoT Device for a certain resource access, for example, to get a
  video stream from user's video camera footage or permission to unlock some rooms in the house. Due to lack of
- proper authentication, he is able to access this information or execute the required action (e.g. opening the 
+ proper authentication, he is able to access this information or execute the required action (e.g. opening the
  targeted door).</td>
 </tr>
 <tr>
@@ -1641,12 +1641,12 @@ the Protocol Binding on the WoT Device.</td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT Devices
   listens to the network and intercepts a legitimate TD sent by one of the WoT Devices. Then it modifies the TD
   to state different authentication method or authority and forwards it to the intended device. The device
-  follow the instructions in the modified TD and sends authentication request to the attacker's specified 
-  location potentially revealing its credentials, such as username and password. Similarly instead of modifying the 
-  legitimate TD, an attack might save it and use iit later on, for example when it would be updated to a newer 
+  follow the instructions in the modified TD and sends authentication request to the attacker's specified
+  location potentially revealing its credentials, such as username and password. Similarly instead of modifying the
+  legitimate TD, an attack might save it and use iit later on, for example when it would be updated to a newer
   version. Then, an attacker substitutes a new version of the TD with an older version to cause DoS to a device
-  trying to get an access to a resource. An additional reason for using an older TD might be exposing a 
-  previously available vulnerable interface that got hidden when the TD was updated to a newer version. This can 
+  trying to get an access to a resource. An additional reason for using an older TD might be exposing a
+  previously available vulnerable interface that got hidden when the TD was updated to a newer version. This can
   be a stepping stone to conducting other attacks on the WoT System.</td>
 </tr>
 <tr>
@@ -1675,42 +1675,42 @@ the Protocol Binding on the WoT Device.</td>
 <tr>
 <td><a>WoT Communication Threat - System User Data Confidentiality and Privacy</a></td>
 <td>A user's party guest with network access to the same internal network as WoT Devices using his device
-listens to the network and intercepts WoT interface exchange between legitimate entities. From that exchange 
-the guest learns privacy-sensitive information about the host, such as a data stream from his medical 
+listens to the network and intercepts WoT interface exchange between legitimate entities. From that exchange
+the guest learns privacy-sensitive information about the host, such as a data stream from his medical
 tracking equipment, information about user's preferences in home environment, video/audio camera stream etc.
 </td>
 </tr>
 <tr>
 <td><a>WoT DoS Threat</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT Devices sends
-  huge amount of requests to either a single WoT Device or all device available in the WoT System using 
+  huge amount of requests to either a single WoT Device or all device available in the WoT System using
   directly Protocol Bindings interface or WoT interface. These requests take all the processing bandwidth of a
-  WoT Device or WoT System and make it impossible for legitimate users to communicate with WoT Devices or 
-  devices to communicate with each other. Depending on the implementation it can also lead to the case that 
+  WoT Device or WoT System and make it impossible for legitimate users to communicate with WoT Devices or
+  devices to communicate with each other. Depending on the implementation it can also lead to the case that
   alarm or authentication systems might be disabled and thieves get into user's house (however systems should
-  always implement "safe defaults" principle and in such cases keeps doors closed despite of inability to 
+  always implement "safe defaults" principle and in such cases keeps doors closed despite of inability to
   authenticate).
 </td>
 </tr>
 <tr>
 <td><a>WoT Communication Threat - Side Channels</a></td>
 <td>A compromised application on a user smartphone connected to the same internal network as WoT Devices
- listens to the WoT System traffic. 
+ listens to the WoT System traffic.
  By this passive listening, he is able to infer various forms of privacy-related
- information, such as WoT System configuration, WoT Devices that are present, 
+ information, such as WoT System configuration, WoT Devices that are present,
  network active and passive phase timing,
- etc. 
+ etc.
 </td>
 </tr>
 </table>
 </section>
- 
+
 <section>
   <h3>Scenario 2 - Business/Corporate Environment</h3>
 
     <p>In this scenario we assume an office building environment shared between a number
      of independent companies (tenants) with a shared WoT System running that controls temperature, lights, video
-     surveillance, air etc. 
+     surveillance, air etc.
      The companies sharing the premises do not trust each other and can be viewed as potential attackers.
      However, we assume that there is a trusted non-compromised <a>System Provider</a>
      that sets the WoT System through the whole building and handles the on-boarding and termination process
@@ -1718,15 +1718,15 @@ tracking equipment, information about user's preferences in home environment, vi
      in the WoT System anymore).
      Compared to Scenario 1 above, the main challenge here is to securely share the WoT System
      between these companies and make sure their WoT <a>System User Data</a> (that can include
-     highly confidential company information) is not exposed, tampered with, etc. 
+     highly confidential company information) is not exposed, tampered with, etc.
      Additionally one has to take into account the fact that a set of building tenants might change from
      time to time, including employee turnover in each company. Therefore the WoT setup
      must be flexible enough to start and terminate access to the WoT System promptly to both
      companies (entire sets of users) and individuals.
      Privacy is also important here, because companies need to make sure that the data about their
-     employees or clients is well protected, including such information as employee presence. 
+     employees or clients is well protected, including such information as employee presence.
      Since we assume the presence of a trusted <a>System Provider</a>, we can consider the WoT scripts and
-     protocol bindings to be trusted also. 
+     protocol bindings to be trusted also.
      Similar to Scenario 1, there is only a single <a>System Provider</a> present on
      physical WoT Devices, and no dynamic installation of WoT scripts are possible for simplicity.
     </p>
@@ -1742,14 +1742,14 @@ tracking equipment, information about user's preferences in home environment, vi
 
     <tr>
     <td><a>WoT Protocol Binding Threat</a></td>
-    <td>This attack is similar to the one described in Scenario 1 where a WoT System shares 
-     connectivity with other non-WoT Devices (smartphones, PCs, etc.). 
+    <td>This attack is similar to the one described in Scenario 1 where a WoT System shares
+     connectivity with other non-WoT Devices (smartphones, PCs, etc.).
      In this case a company's employee can send a malformed request to a WoT Device targeting a
-     Protocol Binding interface directly. 
+     Protocol Binding interface directly.
      This malformed request causes the respective Protocol Binding to be compromised and attacker
-     is able to run the code with the privileges of the Protocol Binding on the WoT Device. 
-     As a result the attacker can get any WoT asset from that device, including <a>System User Data</a> 
-     from another company. 
+     is able to run the code with the privileges of the Protocol Binding on the WoT Device.
+     As a result the attacker can get any WoT asset from that device, including <a>System User Data</a>
+     from another company.
      </td>
     </tr>
     <tr>
@@ -1763,7 +1763,7 @@ tracking equipment, information about user's preferences in home environment, vi
     <td>An employee with network access to the same internal network as WoT Devices using his device
     sends a WoT interface request to obtain the data from a WoT video camera device located in a meeting
     room of another company or to unlock the door to another company's office wing. Due to lack of proper
-    authentication, he is able to access this information or execute the targeted action 
+    authentication, he is able to access this information or execute the targeted action
     (e.g. opening the door and getting physical access to another company's premises).
     </td>
     </tr>
@@ -1776,7 +1776,7 @@ tracking equipment, information about user's preferences in home environment, vi
     <tr>
     <td><a>WoT Communication Threat - TD Confidentiality and Privacy</a></td>
     <td>If we assume that all Things and their TDs are standard to
-    the building, then unlike Scenario 1 we can (perhaps) assume that all info in them is public 
+    the building, then unlike Scenario 1 we can (perhaps) assume that all info in them is public
     (since they relate to System provider and not system users).  However, if companies or employees
     can add their own devices to the WoT System (for instance, wearables or desk lamps) than
     the system may have to protect non-public TDs.
@@ -1805,12 +1805,12 @@ tracking equipment, information about user's preferences in home environment, vi
     <td>
       An employee with network access to the same internal network as WoT Devices using his device
       sends a huge number of requests to either a single WoT Device or all devices available in the WoT System
-      using either the Protocol Bindings interface directly or the WoT interface. 
+      using either the Protocol Bindings interface directly or the WoT interface.
       These requests consume all the processing or bandwidth of a WoT Device or WoT System and make it impossible
-      for employees of other company to communicate with WoT Devices or devices to communicate with each 
+      for employees of other company to communicate with WoT Devices or devices to communicate with each
       other. Depending on the implementation it might also lead to alarm or authentication systems
       being disabled and allowing attackers to get into other company's premises (however systems should always
-      implement "safe defaults" principle and in such cases keeps doors closed despite of inability to 
+      implement "safe defaults" principle and in such cases keeps doors closed despite of inability to
       authenticate; but this causes the opposite problem of denying authorized users access and disrupting
       legitimate business).
     </td>
@@ -1829,46 +1829,46 @@ tracking equipment, information about user's preferences in home environment, vi
    <h3>Scenario 3 - Industrial/Critical Infrastructure Environment</h3>
 
    <p>In this scenario we assume an industrial factory or infrastructure (power plant, water distribution
-     system, etc.) environment that is using WoT System 
+     system, etc.) environment that is using WoT System
      to monitor or perform certain automation tasks in its Operational Technology (OT) network.
      Compared to other scenarios above, the main challenge here is to guarantee safety and availability
-     of the critical infrastructure. 
-     Therefore, for example, Denial-Of-Service attacks must be mitigated as well as possible. 
-     On the other hand, privacy is usually less important for this scenario. 
+     of the critical infrastructure.
+     Therefore, for example, Denial-Of-Service attacks must be mitigated as well as possible.
+     On the other hand, privacy is usually less important for this scenario.
     </p>
     <p>
      Similar to the previous scenarios, we assume that there is a trusted non-compromised <a>System Provider</a>
      that sets up the WoT System, so we can consider all WoT scripts and protocol bindings to be
-     trusted also. 
+     trusted also.
      We also assume there is only a single <a>System Provider</a> present on physical WoT Devices and
      a single tenant on all system, and assume no
      dynamic installation of WoT scripts is possible for simplicity.
     </p>
     <p>
-     Due to the high safety and availability requirements in the industrial environment, 
+     Due to the high safety and availability requirements in the industrial environment,
      typically the WoT System (part of a bigger OT network) won't be shared with other tenants of the same
      building and normally won't be shared with the general IT network of the same company.
-     The IT network is where all other company operations are happening, for example, accounting. 
+     The IT network is where all other company operations are happening, for example, accounting.
      We also don't expect factory employees to browse the internet in the coffee break using the OT network
-     (and ideally not the IT network; in some companies, a third network is even provided for employee personal use 
-     or for less-trusted personal devices.) 
+     (and ideally not the IT network; in some companies, a third network is even provided for employee personal use
+     or for less-trusted personal devices.)
      However, usually some bridging must be present between the OT
-     and IT networking in order to support monitoring requirements, so these networks are not fully isolated. 
-     In this scenario, 
-     the risk of compromised devices and applications interacting with the WoT System is limited 
+     and IT networking in order to support monitoring requirements, so these networks are not fully isolated.
+     In this scenario,
+     the risk of compromised devices and applications interacting with the WoT System is limited
      but nonetheless present.
      Therefore the usual WoT threats, described in the previous scenarios, still apply, if a malicious
-     application or device gets into the industrial OT WoT System. 
+     application or device gets into the industrial OT WoT System.
     </p>
     <p>
      Also, a factory employee with authorized access to
-     the OT WoT System can be also viewed as a potential attacker. 
+     the OT WoT System can be also viewed as a potential attacker.
      The additional security challenge in this case is role management, i.e. distribution of authorized
      accesses between the actors (factory employees, devices with actuators, etc.) in such a way that a single
      misbehaving actor does not have enough authorization to endanger the safety and availability of the whole
-     infrastructure. 
-     Similar to the case in Scenario 2, the ability to promptly terminate an employees’ access rights to the 
-     WoT System when necessary, and without disrupting other activities, is essential. 
+     infrastructure.
+     Similar to the case in Scenario 2, the ability to promptly terminate an employees’ access rights to the
+     WoT System when necessary, and without disrupting other activities, is essential.
     </p>
 
    </section>
@@ -1878,16 +1878,16 @@ tracking equipment, information about user's preferences in home environment, vi
 
 <section id="wot-privacy">
       <h1>Privacy Considerations</h1>
-            <p>              
+            <p>
               In this section we focus specifically on the privacy aspects that are important to keep in mind
-              while developing and deploying WoT solutions. 
+              while developing and deploying WoT solutions.
 	      The threat model, described in <a href="#wot-threat-model"></a>,
               already takes into account numerous privacy-related threats and aspects.
 	      However, this section summarizes them and gives guidelines
-              and recommendations specifically aimed at minimizing privacy-related risks. 
+              and recommendations specifically aimed at minimizing privacy-related risks.
             </p>
-            <p>              
-              The following WoT privacy threats can potentially affect the privacy of WoT <a>system users</a>:              
+            <p>
+              The following WoT privacy threats can potentially affect the privacy of WoT <a>system users</a>:
              <table>
                 <tr>
                 <th><strong>Privacy threat name</strong></th>
@@ -1902,12 +1902,12 @@ tracking equipment, information about user's preferences in home environment, vi
                       of information that is publicly available about a WoT Thing.
                       There has to be a way (if a TD is privacy-sensitive) to limit clients who can
                       obtain a certain TD (or its privacy-sensitive parts) via authentication and
-                      authorization methods. 
+                      authorization methods.
 		      It is also possible to expose a number of TD variants
-                      for the same WoT Thing based on the level of client's access.  
+                      for the same WoT Thing based on the level of client's access.
                       This recommendation corresponds to the data minimization
                       and security (unauthorized usage, peer entity authentication and confidentiality)
-                      treat mitigation strategies outlined in 
+                      treat mitigation strategies outlined in
 		      [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>.
                       </td>
                 </tr>
@@ -1917,7 +1917,7 @@ tracking equipment, information about user's preferences in home environment, vi
                       between a WoT endpoint (Client, Servient or Device) and a Thing Directory.
                       For example one can learn information about the configuration of a target
 		      WoT System by observing the TDs
-                      that the target WoT System downloads from a Thing Directory. 
+                      that the target WoT System downloads from a Thing Directory.
                       In addition, loading JSON-LD context files might also leak WoT System configuration.
 		      For example, context files may be used to allow TDs to be extended with
 		      new protocols and security schemes; loading these context files then
@@ -1928,11 +1928,11 @@ tracking equipment, information about user's preferences in home environment, vi
                       (for example, a guest visiting a person's home with access to a private wireless access point)
                       to query available WoT Devices (there has to be a way to limit WoT Devices'
                       ability to respond to different broadcast events) and as a result obtaining
-                      WoT System configuration. 
-                      Caching on gateways can help with the JSON-LD context files loading problem.  
+                      WoT System configuration.
+                      Caching on gateways can help with the JSON-LD context files loading problem.
                       This recommendation corresponds to the data minimization
                       and security (unauthorized usage, peer entity authentication and confidentiality)
-                      treat mitigation strategies outlined in 
+                      treat mitigation strategies outlined in
                       [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>. </td>
                 </tr>
                 <tr>
@@ -1941,41 +1941,41 @@ tracking equipment, information about user's preferences in home environment, vi
                       between the WoT Consumer and WoT Thing via many intermediate nodes, such as an Intermediary (WoT
                       Servient) or non-WoT nodes. If these nodes can access or process the WoT
                       <a>system user data</a>, they can unintentionally leak information impacting
-                      the privacy of WoT <a>System Users</a>. 
+                      the privacy of WoT <a>System Users</a>.
 		      In addition, if WoT interfaces are publicly
-                      accessible (for example allowing anyone to query the state of WoT Thing), 
+                      accessible (for example allowing anyone to query the state of WoT Thing),
 		      it can also leak WoT
                       <a>System User Data</a>.</td>
                  <td>WoT Things should minimize publicly accessible WoT interfaces.
                       If WoT System User Data is privacy-sensitive and travels via intermediate
-                      nodes, end-to-end encryption methods and object level security should be preferred. 
-		      This recommendation 
+                      nodes, end-to-end encryption methods and object level security should be preferred.
+		      This recommendation
                       corresponds to the data minimization and security (inappropriate usage,
-                      unauthorized usage and confidentiality) treat mitigation strategies outlined in 
+                      unauthorized usage and confidentiality) treat mitigation strategies outlined in
                       [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>.</td>
                 </tr>
                 <tr>
                  <td><dfn>Tracking WoT System User</dfn></td>
                  <td> According to the WoT specification, each TD includes a unique identifier (id), but it
-                      is not specified how such identifier should be generated and the duration of its 
+                      is not specified how such identifier should be generated and the duration of its
 		      validity.
                       Typically such identifiers are generated using various methods outlined in
                       [[Lea05]] - <cite>A Universally Unique IDentifier (UUID) URN Namespace</cite>.
-                      If this identifier is a persistent unique identifier that is never changed during device 
+                      If this identifier is a persistent unique identifier that is never changed during device
                       lifecycle (immutable) or changed very rarely (for example only when a WoT System is
                       installed and bootstrapped), then a WoT Device and a WoT <a>System User</a> might
                       be uniquely identified and its communications tracked.
-                      Similar tracking can be done even without identifiers by using 
+                      Similar tracking can be done even without identifiers by using
 		      fingerprinting techniques based on
                       a WoT System configuration information (which is likely to be unique).</td>
-                 <td>A TD should avoid exposing publically any persistent unique identifiers 
+                 <td>A TD should avoid exposing publically any persistent unique identifiers
 		      (especially immutable ones)
-                      that can be used to track it. 
+                      that can be used to track it.
 		      Ideally, a TD's identifier (id) should be changed
                       periodically (potentially even every time the WoT Exposed Thing is created, if it does
                       not infer the normal operation mode of a WoT Thing).
-		      This however conflicts with the needs of Linked Data and the registration of 
-		      Things in directories and their use by other Things.  
+		      This however conflicts with the needs of Linked Data and the registration of
+		      Things in directories and their use by other Things.
 		      A compromise needs to be struck.  Mechanisms to notify
 		      legitimate users of a Thing when a Thing's identifier has changed may be considered
 		      if frequent updates are necessary.
@@ -1987,9 +1987,9 @@ tracking equipment, information about user's preferences in home environment, vi
              </table>
              In addition to the mitigations described above, it is also important to keep <a>System Users</a>
              informed about the information that can be exposed and/or collected about them, as well as to have
-             a way for <a>System Users</a> to control the degree of such exposure. 
+             a way for <a>System Users</a> to control the degree of such exposure.
 	     This recommendation
-             corresponds to the user participation in treat mitigation strategy outlined in 
+             corresponds to the user participation in treat mitigation strategy outlined in
              [[Coo13]] - <cite>Privacy Considerations for Internet Protocols</cite>.
             </p>
 
@@ -1997,8 +1997,8 @@ tracking equipment, information about user's preferences in home environment, vi
             We need to mention privacy risks associated with links.
 	    In particular, dereferencing links carries similar inferencing risks
 	    as context file dereferencing.
-            This has been mentioned in the Security and Privacy 
-            sections of [[WoT-Architecture]] and 
+            This has been mentioned in the Security and Privacy
+            sections of [[WoT-Architecture]] and
             [[WoT-Thing-Description]] but needs to be expanded upon here.
           </p>
 
@@ -2009,8 +2009,8 @@ tracking equipment, information about user's preferences in home environment, vi
   <h1>Security Provisioning(Onboarding) and Maintenance</h1>
     <section>
     <h2>Goals and requirements</h2>
-    <p>   
-    Following the lifecycle diagram  <a href="#wot-lifecycle"></a> , 
+    <p>
+    Following the lifecycle diagram  <a href="#wot-lifecycle"></a> ,
     the purpose of the Security provisioning
     is that upon its completion a WoT Device is equipped with the security metadata
     and credentials it needs during its Operational state.
@@ -2024,20 +2024,20 @@ tracking equipment, information about user's preferences in home environment, vi
     The purpose of the Security maintenance is maintaining security level set
     during the security provisioning phase,
     i.e. security-related configuration updates, such as key rotation or
-    certificate refresh. This also includes the actions to be taken in case of 
+    certificate refresh. This also includes the actions to be taken in case of
     credential compromise, i.e. key revocation.
     </p>
 
-    Security provisioning usually consists of three main stages outlined below. 
+    Security provisioning usually consists of three main stages outlined below.
     The WoT adds WoT-specific stage at the end:
     <ul>
       <li><strong>Initial enablement.</strong> During manufacturing a device is provisioned with the
-      necessary credentials that enable secure mutual authentication and remote attestation in the next step.</li> 
+      necessary credentials that enable secure mutual authentication and remote attestation in the next step.</li>
       <li><strong> Mutual trust establishment.</strong> Establishing mutual trust between the device to be provisioned
       and the provisioning entity.  Note that the provisioning entity is not necessary (and quite commonly not)
-      a manufacturer, but some service provider or service domain owner. 
+      a manufacturer, but some service provider or service domain owner.
       This includes mutual authentication and authorization for both device and provisioning entity and
-      potentially remote attestation of device.</li> 
+      potentially remote attestation of device.</li>
       <li><strong> Runtime credential provisioning.</strong> The actual provisioning of credentials for the operational
        phase in a secure fashion between the provisioning entity and the device.</li>
        <li><strong> WoT specific provisioning.</strong> Installing the provisioned secrets and made them available and
@@ -2045,16 +2045,16 @@ tracking equipment, information about user's preferences in home environment, vi
     </ul>
 
     <p class="ednote" title="Question1">
-    Do we try to describe only the bootstrapping of the credentials 
+    Do we try to describe only the bootstrapping of the credentials
     into a WoT run time (after which it can be transparently used during operational
     phase) or do we go into describing of how credentials will end up in the physical
     device at the first place, and then how they can be securely retrieved and embedded into
-    WoT run time? 
+    WoT run time?
     </p>
     <p class="ednote" title="Question2">
     Do we limit ourselves to the case of a single tenant (single security domain device joins
     and accepts credentials from a single provisioning entity) or we also take multiple tenants in
-    the scope from beginning? 
+    the scope from beginning?
     </p>
 
     </section>
@@ -2083,14 +2083,14 @@ tracking equipment, information about user's preferences in home environment, vi
       and it is important to keep up to date.
       At the same time,
       IoT is new enough and is itself evolving rapidly enough that best practices
-      are just now emerging and are likely to require rapid updating.  
+      are just now emerging and are likely to require rapid updating.
       Recently attempts have been made to document and categorize useful approaches to security in IoT.
       The following are some of the more useful points of reference:
       <ul>
       <li>[[Garcia17]] - <cite>State-of-the-Art and Challenges for the Internet of Things Security</cite>:<br/>
       This IETF document, a product of the IETF T2TRG, is still in draft form but is now a candidate for
-      ratification. 
-      It covers a range of recommendations for securing IoT systems.  
+      ratification.
+      It covers a range of recommendations for securing IoT systems.
       Readers should look for the latest version using the IETF RFC tracker.</li>
       <li>[[IicSF16]] - <cite>The Industrial Internet of Things Volume G4: Security Framework</cite>:<br/>
       Focuses on industrial IoT systems and use cases, and so as discussed above
@@ -2098,7 +2098,7 @@ tracking equipment, information about user's preferences in home environment, vi
       However, this document includes many practices that are also relevant to other IoT use cases.
       </li>
       <li>[[IETFACE]] - <cite>IETF Authentication and Authorization for Constrained Environments (ACE)</cite>:<br/>
-      Discusses the use of existing IETF standards for constrained environments 
+      Discusses the use of existing IETF standards for constrained environments
       (such as CoAP and DTLS) of relevance to IoT.
       This working group defines building blocks for IoT security esp. addressing authentication and authorization.
       </li>
@@ -2109,7 +2109,7 @@ tracking equipment, information about user's preferences in home environment, vi
       </ul>
     </p><p>
       Here are some additional general references for threat modeling and security architecture planning.
-      These frameworks can be helpful when designing the security architecture of a specific IoT system or 
+      These frameworks can be helpful when designing the security architecture of a specific IoT system or
       standard.  OWASP in particular is useful for Things using the HTTP protocol for their network interface.
       <ul>
       <li>[[Mic17]] - <cite>STRIDE - Internet of Things security architecture</cite></li>
@@ -2117,7 +2117,7 @@ tracking equipment, information about user's preferences in home environment, vi
       <li>[[Owa17]] - <cite>OWASP Threat Risk Modeling</cite></li>
       </ul>
     </p><p>
-      The following documents define the security and privacy considerations 
+      The following documents define the security and privacy considerations
       that should be included in internet standards.
       These references helped define the topics covered in this document.
       <ul>
@@ -2169,14 +2169,14 @@ tracking equipment, information about user's preferences in home environment, vi
   <section id="security-mitigations">
   <h1>Best Security Practices and Mitigations for WoT Systems</h1>
       <p>
-        Based on the main WoT assets, 
-	privacy and security threats listed in <a href="#wot-threat-model-assets"></a>, 
+        Based on the main WoT assets,
+	privacy and security threats listed in <a href="#wot-threat-model-assets"></a>,
 	<a href="#wot-threat-model-threats"></a> and
         <a href="#wot-privacy"></a>, we provide here a set of recommended practices for
         enhancing security and privacy when designing a WoT System.
 	Depending on the usage scenario, these may not be adequate for securing
-	any given WoT System, however.  The full threat model should be 
-	considered to identify and mitigate any additional threats for 
+	any given WoT System, however.  The full threat model should be
+	considered to identify and mitigate any additional threats for
 	a specific WoT System.
       </p>
 
@@ -2184,24 +2184,24 @@ tracking equipment, information about user's preferences in home environment, vi
         <h2>Secure Practices for designing a Thing Description</h2>
 
          <p><strong>Secure Delivery and Storage of Thing Description.</strong></p>
-         <p>            
+         <p>
     	      When a TD is transferred between WoT endpoints, to or from the TD
               hosting service, it is important to use secure protocols guaranteeing
-    	      data authenticity, freshness and in many cases confidentiality 
+    	      data authenticity, freshness and in many cases confidentiality
               (depending on whenever a TD contains any confidential or
-              privacy-sensitive information). 
+              privacy-sensitive information).
 	      TDs should not be provided without first authenticating the requester
 	      and checking that they have authorization to access the requested TDs.
 	      If end-to-end TD authenticity or
               confidentiality is required, see <a href="#sec-pract-end-to-end-security"></a>
-              for more specific guidance. 
+              for more specific guidance.
               When a TD is stored at the end device, in a gateway (e.g. in a cache or directory
 	      service) or in remote storage (e.g. an archive),
               its authenticity and in some cases confidentiality should
-              also be protected using the best available local methods. 
+              also be protected using the best available local methods.
             </p>
             <p>
-  	      This recommendation helps prevent the following threats: 
+  	      This recommendation helps prevent the following threats:
               <a>WoT Communication Threat - TD Authenticity</a>,
               <a>WoT Communication Threat - TD Confidentiality and Privacy</a>,
               <a>Disclosing WoT Thing/Device configuration</a>,
@@ -2212,19 +2212,19 @@ tracking equipment, information about user's preferences in home environment, vi
          <p><strong>Avoid Exposing Persistent Unique Identifiers</strong></p>
             <p>
              When defining fields exposed by a TD immutable information should be avoided,
-	     especially if that information can be tied to a particular person or 
+	     especially if that information can be tied to a particular person or
 	     is associated with personally identifiable information.
-             It is specifically strongly recommended to avoid exposing 
+             It is specifically strongly recommended to avoid exposing
 	     any immutable hardware identifiers.
-             Instead it is recommended to use "soft identifiers", 
+             Instead it is recommended to use "soft identifiers",
 	     i.e. identifiers that can be changed at some point during the device's lifecycle.
 	     Given the requirements of Linked Data, it may not be possible to change
 	     the identifier during the Operational state of a device without additional
-	     infrastructure to register consumers of a TD and notify them of updates, but it should 
+	     infrastructure to register consumers of a TD and notify them of updates, but it should
 	     at least be possible during (re-)provisioning.
             </p>
             <p>
-            This recommendation helps prevent the following threats: 
+            This recommendation helps prevent the following threats:
             <a>WoT Communication Threat - TD Confidentiality and Privacy</a>,
             <a>Disclosing WoT System configuration</a>,
             <a>Tracking WoT System User</a>.
@@ -2233,15 +2233,15 @@ tracking equipment, information about user's preferences in home environment, vi
          <p><strong>Minimize Publicly Exposed Information in TD</strong></p>
             <p>
              WoT TDs should minimize the amount of information that
-             is publicly available about a WoT Thing.             
+             is publicly available about a WoT Thing.
 	     For example, the TD should generally not identify the version of the software or
 	     operating system a device is running, since this information can be used
-	     to identify vulnerable systems.  
+	     to identify vulnerable systems.
 	     Instead the TD should capture all information
 	     needed to support interoperability without reference to particular implementations.
             </p>
             <p>
-            This recommendation helps prevent the following threats: 
+            This recommendation helps prevent the following threats:
             <a>WoT Communication Threat - TD Confidentiality and Privacy</a>,
             <a>Disclosing WoT Thing/Device configuration</a>,
             <a>Disclosing WoT System configuration</a>,
@@ -2253,13 +2253,13 @@ tracking equipment, information about user's preferences in home environment, vi
             <p>
              Limit clients who can obtain a certain TD (or its privacy-sensitive parts)
              via authentication and authorization methods.
-             This can be done by exposing a number of TD variants for the same 
-             WoT Thing based on the level of client’s access.           
+             This can be done by exposing a number of TD variants for the same
+             WoT Thing based on the level of client’s access.
 	     For example, versions of a TD for "public access" may be generated with a subset
 	     of information in the full TD, omitting (for example) support or version metadata.
             </p>
             <p>
-            This recommendation helps prevent the following threats: 
+            This recommendation helps prevent the following threats:
             <a>WoT Communication Threat - TD Confidentiality and Privacy</a>,
             <a>Disclosing WoT Thing/Device configuration</a>,
             <a>Tracking WoT System User</a>,
@@ -2271,26 +2271,26 @@ tracking equipment, information about user's preferences in home environment, vi
         <h2>Secure Practices for protecting System User Data</h2>
 
         <p><strong>Use Secure Transports</strong></p>
-            <p> 
-             When defining protocols for APIs exposed by a TD, 
+            <p>
+             When defining protocols for APIs exposed by a TD,
              it is often important to use secure protocols guaranteeing
              <a>System User Data</a> authenticity and confidentiality.
 	     Specifically, HTTP-over-TLS (HTTPS), CoAP-over-DTLS (COAPS), and
-	     MQTT-over-TLS (MQTTS) should be used if any kind of authentication 
+	     MQTT-over-TLS (MQTTS) should be used if any kind of authentication
 	     or secure access is required.
              If data travels over many intermediate nodes (potentially malicious
              or not privacy-preserving), end-to-end encryption
              methods should be preferred.
             </p>
             <p>
-            This recommendation helps prevent the following threats: 
+            This recommendation helps prevent the following threats:
             <a>WoT Communication Threat - System User Data Authenticity</a>,
             <a>WoT Communication Threat - System User Data Confidentiality and Privacy</a>,
             <a>Leaking WoT System User Data</a>.
             </p>
- 
+
         <p><strong>User Consent</strong></p>
-            <p> 
+            <p>
             Keep <a>System Users</a> informed about the information that can
             be exposed or collected about them.
             Provide a way for <a>System Users</a> to control the degree of such exposure.
@@ -2302,7 +2302,7 @@ tracking equipment, information about user's preferences in home environment, vi
             </p>
       </section>
 
-    
+
    <section id="sec-pract-wot-interfaces">
       <h2>Secure Practices for designing WoT Interfaces</h2>
 
@@ -2310,14 +2310,14 @@ tracking equipment, information about user's preferences in home environment, vi
             <p>
               Use Security Metadata options to configure appropriate
               authentication and authorization methods for WoT Interfaces
-              exposed by a WoT Thing. 
+              exposed by a WoT Thing.
 	      Minimize the amount of WoT Interfaces
               without any access control defined (including emitting public
-              events). 
+              events).
               Consider different levels of access for different users.
             </p>
             <p>
-             This recommendation helps prevent the following threats: 
+             This recommendation helps prevent the following threats:
              <a>WoT Interface Threat - Unauthorized WoT Interface Access</a>,
              <a>WoT Interface Threat - Exposed Thing Compromise</a>,
              <a>WoT Communication Threat - System User Data Authenticity</a>,
@@ -2330,12 +2330,12 @@ tracking equipment, information about user's preferences in home environment, vi
           <p><strong>Avoid Heavy Functional Processing without Authentication</strong></p>
             <p>
               When defining WoT Interfaces exposed by a TD,
-              it is important to avoid any heavy functional processing 
+              it is important to avoid any heavy functional processing
 	      before the successful authentication of a WoT Consumer.
-              Any publicly exposed network interface should avoid heavy processing altogether. 
+              Any publicly exposed network interface should avoid heavy processing altogether.
             </p>
             <p>
-             This recommendation helps prevent the following threats: 
+             This recommendation helps prevent the following threats:
             <a>WoT DoS Threat</a>.
             </p>
 
@@ -2356,9 +2356,9 @@ tracking equipment, information about user's preferences in home environment, vi
 
          <p><strong>Strong Validation and Fuzz Testing on All WoT Interfaces</strong></p>
           <p>
-           All WoT Interfaces (and especially public ones) 
-	   should be well-tested (including fuzz testing) and validated 
-	   since they are a primary attack surface of a WoT Thing. 
+           All WoT Interfaces (and especially public ones)
+	   should be well-tested (including fuzz testing) and validated
+	   since they are a primary attack surface of a WoT Thing.
           </p>
           <p>
            This recommendation helps prevent the following threats:
@@ -2388,20 +2388,20 @@ tracking equipment, information about user's preferences in home environment, vi
       <section id="sec-pract-end-to-end-security">
         <h2>Secure Practices for End-to-End security</h2>
             <p>
-              The notion 'end-to-end' security (short: E2E security) is often encountered when security 
-	      is considered. Quite often, this notion is encountered in a way that is misleading: it is a 
-	      matter of risk assessment to determine the "ends" that are to be protected in a distributed 
-	      system such as WoT (identifying the domain-of-protection) and then select one or more security 
-	      technologies to fulfill the identified demand (not: vice versa). 
+              The notion 'end-to-end' security (short: E2E security) is often encountered when security
+	      is considered. Quite often, this notion is encountered in a way that is misleading: it is a
+	      matter of risk assessment to determine the "ends" that are to be protected in a distributed
+	      system such as WoT (identifying the domain-of-protection) and then select one or more security
+	      technologies to fulfill the identified demand (not: vice versa).
             </p>
             <p>
-              In that sense, there is no single, universal notion of E2E security in WoT. There is also no 
-	      single security technology that allows to deliver E2E security for any definition of the ends. 
-	      The perception of WoT security is to support users of WoT in implementing security architectures 
-	      according their perception of the ends (which can vary across users, deployments etc.) using for 
+              In that sense, there is no single, universal notion of E2E security in WoT. There is also no
+	      single security technology that allows to deliver E2E security for any definition of the ends.
+	      The perception of WoT security is to support users of WoT in implementing security architectures
+	      according their perception of the ends (which can vary across users, deployments etc.) using for
 	      instance:
 	      <ul>
-                 <li>CMS as well as XML/JSON/CBOR security (IETF resp. W3C) to provide E2E security on the level 
+                 <li>CMS as well as XML/JSON/CBOR security (IETF resp. W3C) to provide E2E security on the level
 		     of application data</li>
                  <li>(D)TLS (IETF) to provide E2E security between client and server processes</li>
                  <li>IPsec (IETF) to provide E2E security between endpoints in an IP-based inter-network</li>
@@ -2409,34 +2409,34 @@ tracking equipment, information about user's preferences in home environment, vi
               </ul>
             </p>
 	    <p>
-              The following technologies allow to address E2E security in the first sense (protecting exchanges 
+              The following technologies allow to address E2E security in the first sense (protecting exchanges
 	      between WoT system components on the level of application data):
 	      <ul>
-                 <li>If authenticity is desired for exchanged application data, then sign WoT objects (TDs, system 
-	             user data) using either digital signatures (using asymmetric cryptographic primitives) or Message 
-	             Authentication Codes (MACs, using symmetric cryptographic primitives). Such digital signatures or 
-		     MACs are created by the producers/issuers of the objects and validated by consumers of the objects 
-		     (which should reject signed the objects whose signatures/MACs are invalid). For data expressed in 
-		     JSON, [[JWS15]] provides a guideline for expressing digital signatures or MACs as well as related 
+                 <li>If authenticity is desired for exchanged application data, then sign WoT objects (TDs, system
+	             user data) using either digital signatures (using asymmetric cryptographic primitives) or Message
+	             Authentication Codes (MACs, using symmetric cryptographic primitives). Such digital signatures or
+		     MACs are created by the producers/issuers of the objects and validated by consumers of the objects
+		     (which should reject signed the objects whose signatures/MACs are invalid). For data expressed in
+		     JSON, [[JWS15]] provides a guideline for expressing digital signatures or MACs as well as related
 		     security metadata using JSON-based data structures. [[COSE17]] does the same for CBOR.</li>
-                 <li>If confidentiality is desired for exchanged application data, then encrypt WoT objects using well-known 
-		     encryption primitives. For data expressed in JSON, [[JWE15]] provides a guideline for expressing 
-	             encrypted data as well as related security metadata using JSON-based data structures. [[COSE17] does 
+                 <li>If confidentiality is desired for exchanged application data, then encrypt WoT objects using well-known
+		     encryption primitives. For data expressed in JSON, [[JWE15]] provides a guideline for expressing
+	             encrypted data as well as related security metadata using JSON-based data structures. [[COSE17] does
 	             the same for CBOR. Moreover the following is important here:
 		     <ul>
-                         <li>Confidentiality without authenticity (i.e. encryption-only) does not provide a secure scheme. 
+                         <li>Confidentiality without authenticity (i.e. encryption-only) does not provide a secure scheme.
 		             Use authenticated encryption, not encryption-only to provide confidentiality</li>
-                         <li>Classical cryptographic schemes (pre-AEAD, see [[AEAD08]]) cover encryption-only as well as 
-		             authentication-only. This requires users of cryptographic schemes to create an own design to 
-			     deliver authenticated encryption and this tends to go wrong. Use AEAD schemes to deliver 
-		             authenticated encryption (or use an underlying security protocol such as (D)TLS – when this can 
+                         <li>Classical cryptographic schemes (pre-AEAD, see [[AEAD08]]) cover encryption-only as well as
+		             authentication-only. This requires users of cryptographic schemes to create an own design to
+			     deliver authenticated encryption and this tends to go wrong. Use AEAD schemes to deliver
+		             authenticated encryption (or use an underlying security protocol such as (D)TLS – when this can
 			     fulfill the identified E2E security demand)</li>
                       </ul>
 		 </li>
               </ul>
             </p>
             <p>
-            This recommendation helps prevent the following threats: 
+            This recommendation helps prevent the following threats:
             <a>WoT Communication Threat - System User Data Authenticity</a>,
             <a>WoT Communication Threat - System User Data Confidentiality and Privacy</a>,
             <a>Leaking WoT System User Data</a>,
@@ -2473,7 +2473,7 @@ tracking equipment, information about user's preferences in home environment, vi
             </figure>
             <p>
             From a security point of view two aspects are important to consider in this scenario.
-            First, the WoT Consumer should be certain that it is talking to the correct WoT Thing 
+            First, the WoT Consumer should be certain that it is talking to the correct WoT Thing
 	    and not to some other device exposed on the same network.
             Users intending to control a specific device, for example opening a garage door,
             want to make sure they are talking to their own garage door device.
@@ -2481,7 +2481,7 @@ tracking equipment, information about user's preferences in home environment, vi
             authenticate the device exposing the WoT Thing.
             Second, upon receiving requests from a WoT Consumer,
             the WoT Thing must verify the the WoT Consumer is authorized to perform such requests.
-            For example, a garage door must only process "open" requests from devices associated with 
+            For example, a garage door must only process "open" requests from devices associated with
             authorized users or service providers and not from arbitrary passerby.
             </p>
             <p>
@@ -2507,18 +2507,18 @@ tracking equipment, information about user's preferences in home environment, vi
             each other given that there is a way to supply credential information required for authentication
             during provisioning:
             <ul>
-            <li><strong>Symmetric key credentials.</strong> 
+            <li><strong>Symmetric key credentials.</strong>
 		    This method assumes that both WoT Consumer and the device exposing WoT Thing have pre-shared
 		    symmetric key credentials.
 		    Such keys can be established during device provisioning/on-boarding phase.
 		    In this case, since this is actually an OCF device,
-		    it can use one of the methods recommended in Section 7 [[Ocf17]] 
+		    it can use one of the methods recommended in Section 7 [[Ocf17]]
 		    or can use an ad-hoc security protocol,
 		    such as EC Diffie-Hellmani, based on other existing pre-shared credentials.
 		    See Section 9.2.1 [[Ocf17]] for more details on such credential types.</li>
             <li><strong>Raw asymmetric public key credentials.</strong>
 		    This method assumes that a WoT Consumer has been provisioned with the public key
-		    of the device exposing the WoT Thing (and vice versa) 
+		    of the device exposing the WoT Thing (and vice versa)
 		    so the devices are able to mutually authenticate each other.
 		    Provisioning of public keys can take place during a device provisioning/on-boarding phase.
 		    In the case of OCF devices,
@@ -2526,32 +2526,32 @@ tracking equipment, information about user's preferences in home environment, vi
 		    Section 9.2.3 [[Ocf17]] also provides more details on this credential type as well as
 		    guidance on its secure provisioning.</li>
             <li><strong>Certificates.</strong> This method assumes that the WoT Consumer has been provisioned
-		    with the certificate of the device exposing the WoT Thing (and visa versa) 
+		    with the certificate of the device exposing the WoT Thing (and visa versa)
 		    so the devices are able to mutually authenticate each other.
 		    The provisioning of the certificates can take place during device provisioning/on-boarding phase
 		    using one of the methods recommended in Section 7 [[Ocf17]].
-		    Section 9.2.5 [[Ocf17]] also provides more details on this 
+		    Section 9.2.5 [[Ocf17]] also provides more details on this
 		    credential type as well as Section 9.3.</li>
             </ul>
             </p>
             <p>
             In case it is not possible to pre-provision any of the types of credentials described above
 	    during the network setup phase or if the WoT Thing wants to use a more fine-grained access control policy
-	    on the WoT Interfaces it is exposing 
+	    on the WoT Interfaces it is exposing
 	    (for example, different controls might require different levels
 	    of authorization), the following methods can be used instead:
             <ul>
             <li><strong>OAuth 2.0-based access tokens.</strong> These tokens follow the JSON Web Token (JWT)
-		    format defined in RFC 7519 [[JWT15]] and should used according to the suggestions by 
-		    the IETF Authentication and Authorization for Constrained Environments (ACE) 
+		    format defined in RFC 7519 [[JWT15]] and should used according to the suggestions by
+		    the IETF Authentication and Authorization for Constrained Environments (ACE)
 		    specification draft [[IETFACE]].
 		    These are recommended for devices that are able to use the HTTP protocol and
 		    do not have significant resource constraints.</li>
-            <li><strong>Proof-of-possession (PoP) tokens.</strong> These are extensions of the OAuth 2.0-based 
+            <li><strong>Proof-of-possession (PoP) tokens.</strong> These are extensions of the OAuth 2.0-based
 		    access tokens that follow the CBOR web token (CWT) format [[CBOR17]].
-		    The IETF Authentication and Authorization for Constrained Environments (ACE) 
+		    The IETF Authentication and Authorization for Constrained Environments (ACE)
 		    specification draft [[IETFACE]]
-		    recommends such tokens for resource-constrained devices using the COAP protocol 
+		    recommends such tokens for resource-constrained devices using the COAP protocol
 		    instead of HTTP.
 		    For details of using such tokens please see [[IETFACE]].</li>
             </ul>
@@ -2559,34 +2559,34 @@ tracking equipment, information about user's preferences in home environment, vi
             <p>
             Instead of assigning different access tokens to different WoT Interfaces,
             it is also possible to group related WoT Interfaces under some group or capability name
-            (i.e. "Light controls", "House access" etc.) 
+            (i.e. "Light controls", "House access" etc.)
 	    and assign one token per group to guard any such interfaces.
             This can provide more balanced access control granularity in many circumstances.
             </p>
             <p>
-            Suitable choices of the above security measures allows mitigation of the 
+            Suitable choices of the above security measures allows mitigation of the
 	    <a>WoT Interface Threat - Unauthorized WoT Interface Access</a> threat.
             </p>
             <p>
             In addition to the above measures,
-	    authenticity, confidentiality and replay protection of transferred solution data and of 
+	    authenticity, confidentiality and replay protection of transferred solution data and of
 	    TDs between the WoT Consumer and the WoT Thing is strongly recommended for scenarios
 	    where an attacker can observe or/and modify the traffic in the WoT System.
-            While TD transfer might only require authenticity protection, 
+            While TD transfer might only require authenticity protection,
 	    the solution data itself usually requires protection of all its aspects.
             This helps to mitigate the following threats:
-            <a>WoT Communication Threat - TD Authenticity</a>, 
+            <a>WoT Communication Threat - TD Authenticity</a>,
 	    <a>WoT Communication Threat - TD Confidentiality and Privacy</a>,
             <a>WoT Communication Threat - System User Data Authenticity</a>,
             <a>WoT Communication Threat - System User Data Confidentiality and Privacy</a>.
             </p>
             <p>
-            Authenticity, confidentiality and replay protection can be guaranteed by usage of secure 
+            Authenticity, confidentiality and replay protection can be guaranteed by usage of secure
 	    transport protocols to exchange data between the WoT Consumer and the WoT Thing, such as TLS/DTLS.
             If the underlying protocol does not provide the required security (such as plain CoAP run over
 	    a non-(D)TLS protected channel), then authenticity and confidentiality of the transferred data
 	    can be implemented separately on the application layer.
-	    The recommended method for doing this in resource constrained environments is to use the 
+	    The recommended method for doing this in resource constrained environments is to use the
 	    Object Security of CoAP (OSCoAP) method described in the IETF Object Security of CoAP (OSCoAP)
 	    specification draft [[OSCOAP17]].
             </p>
@@ -2594,7 +2594,7 @@ tracking equipment, information about user's preferences in home environment, vi
             The scenario shown in <a href="#wot_client_thing_basic_2"></a> is similar but with the important
 	    difference that a Thing description is not stored on the WoT Thing device nor returned by it directly.
             The TD is instead provided to the WoT Consumer from a Thing Directory residing on some other
-	    system, such as a cloud server.  
+	    system, such as a cloud server.
 	    This mode may be useful for "retro-fitting" existing devices with Thing Descriptions, for example,
 	    or when more secure access to the TD is required than the device itself can support.
             </p>
@@ -2613,21 +2613,21 @@ tracking equipment, information about user's preferences in home environment, vi
             In case the remote cloud does not guarantee the secure storage and delivery of
             Thing Descriptions to the WoT Consumer or in case the remote cloud is not a trusted entity,
 	    the authenticity of the Thing Description should be verified using other methods on the application layer,
-            such as wrapping the Thing Description into a protected 
+            such as wrapping the Thing Description into a protected
 	    CBOR Object Encryption and Signing (COSE) object [[COSE17]].
-            This can be done by the provider of the Thing Description and verified by the 
+            This can be done by the provider of the Thing Description and verified by the
 	    WoT Consumer after the download from the remote cloud.
             </p>
           </section>
           <section>
           <h2>Interaction between WoT Thing and WoT Consumer via an Intermediary WoT Servient</h2>
             <p>
-            A <a href="#wot_client_thing_gateway"></a>, 
+            A <a href="#wot_client_thing_gateway"></a>,
 	    as in the <a href="#wot_client_thing_basic"></a> configuration,
             also allows a WoT Consumer to connect to and operate or monitor a WoT Thing.
             However in contrast to the basic (direct connection) case,
             the interaction between the WoT Consumer and the WoT Thing is now mediated by an Intermediary WoT Servient.
-            The Intermediary WoT Servient exposes a WoT interface and provides a Thing Description that describes 
+            The Intermediary WoT Servient exposes a WoT interface and provides a Thing Description that describes
             interactions that that apply to the Thing.
             In general, the TD provided by the Intermediary WoT Servient is structurally
             identical to the one that would have been provided by the Thing directly,
@@ -2639,9 +2639,9 @@ tracking equipment, information about user's preferences in home environment, vi
               <figcaption>WoT Thing and WoT Consumer via Intermediary WoT Servient</figcaption>
             </figure>
             <p>
-            From a security standpoint this case is quite similar to the one described in 
-	    Section <a href="#wot-client-server-basic"></a>. 
-            The main difference is that mutual authentication should be established between 
+            From a security standpoint this case is quite similar to the one described in
+	    Section <a href="#wot-client-server-basic"></a>.
+            The main difference is that mutual authentication should be established between
 	    all directly communicating parties,
             i.e. between the WoT Consumer and the Intermediary WoT Servient,
             as well as between the Intermediary WoT Servient and the device exposing the WoT Thing network interface.
@@ -2651,24 +2651,24 @@ tracking equipment, information about user's preferences in home environment, vi
             are also applicable for this case.
             </p>
             <p>
-            The Thing Description that the Intermediary WoT Servient device provides to the WoT Consumer 
-            can be the same as it gets from the device exposing the WoT Thing or it can be modified 
+            The Thing Description that the Intermediary WoT Servient device provides to the WoT Consumer
+            can be the same as it gets from the device exposing the WoT Thing or it can be modified
             to better suit the deployment use case or expose additional functionality via the Intermediary WoT Servient.
             It is also possible that the end device behind the Intermediary WoT Servient is a non-WoT Device and does
-            not provide any Thing Description on its own, 
+            not provide any Thing Description on its own,
 	    and may not support any interaction via a WoT-compatible network Interface.
             In this case the Intermediary WoT Servient has to build the Thing Description by itself i
 	    and expose it to the WoT Consumer.
             For all typical use cases,
             the Intermediary WoT Servient should be considered a trusted entity and in this case
-            it can freely modify or build Thing Descriptions it exposes as well as set up 
+            it can freely modify or build Thing Descriptions it exposes as well as set up
             fine-grained access controls on different exposed WoT Interfaces.
             The Intermediary WoT Servient can do this using the same methods described in
             Section <a href="#wot-client-server-basic"></a>, i
 	    and therefore acts fully on behalf of the end device.
             </p>
             <p>
-            <a href="#wot_client_thing_gateway_2"></a> is similar to the previous case 
+            <a href="#wot_client_thing_gateway_2"></a> is similar to the previous case
 	    but with an important difference:
             a Thing Description is not provided by the the Intermediary WoT Servient,
             but can be fetched by the WoT Consumer from a Thing Directory residing on a remote system.
@@ -2676,14 +2676,14 @@ tracking equipment, information about user's preferences in home environment, vi
             this Thing Description can either be the original Thing Description supplied by the end device
             or modified by the Intermediary WoT Servient.
             Regardless of the actual setup,
-            the transfer of a Thing Description between any two endpoints should be done 
+            the transfer of a Thing Description between any two endpoints should be done
 	    using underlying secure protocols.
             Currently the use of TLS or DTLS is recommended.
-            Similarly to Section <a href="#wot-client-server-basic"></a>, 
+            Similarly to Section <a href="#wot-client-server-basic"></a>,
 	    in case the remote system does not guarantee
             the secure storage and delivery of Thing Descriptions to the WoT Consumer
             or in case the remote system is not a trusted entity,
-            the authenticity of the Thing Description should be verified 
+            the authenticity of the Thing Description should be verified
 	    using other methods in the application layer.
             </p>
             <figure id="wot_client_thing_gateway_2">
@@ -2699,30 +2699,30 @@ tracking equipment, information about user's preferences in home environment, vi
             <a href="#wot_client_thing_double_proxy"></a> shows another common situation
             where the WoT Thing resides in a local protected network, e.g. behind a NAT/Firewall.
             In this case the WoT Consumer cannot contact the WoT Thing directly.
-            In the configuration shown here the communication between the WoT Consumer and the WoT Thing 
-            is handled via a pair of Intermediary WoT Servients: 
+            In the configuration shown here the communication between the WoT Consumer and the WoT Thing
+            is handled via a pair of Intermediary WoT Servients:
             one residing in the local protected network, known as the Local Intermediary WoT Servient,
             and another running in the cloud, known as the Remote Intermediary WoT Servient.
-            We refer to this configuration as a "Split Proxy" because the 
+            We refer to this configuration as a "Split Proxy" because the
 	    combination of the Local and Remote Proxy together
             act like a single proxy service.
-            The Local and Remote Intermediary WoT Servients are connected with a secure channel 
-	    (which may be non-WoT, eg it does not have to use a protocol known to WoT) 
+            The Local and Remote Intermediary WoT Servients are connected with a secure channel
+	    (which may be non-WoT, eg it does not have to use a protocol known to WoT)
 	    as the Local Intermediary WoT Servient only communicates over this channel with the Remote Intermediary WoT Servient.
-            The WoT Remote Intermediary WoT Servient should use the mechanisms described in 
+            The WoT Remote Intermediary WoT Servient should use the mechanisms described in
 	    Section <a href="#wot-client-server-basic"></a>
             in order to authenticate and authorize the WoT Consumer before processing any of its requests.
             Similar to the configurations described in Section <a href="#wot-client-server-basic"></a>,
-            secure protocols should be used to protect authenticity and confidentiality 
+            secure protocols should be used to protect authenticity and confidentiality
 	    and provide replay protection when
             data is exchanged between the WoT Consumer and the Remote Intermediary WoT Servient.
             If the WoT Consumer is authorized,
-            then the Remote Intermediary WoT Servient can package the WoT request 
+            then the Remote Intermediary WoT Servient can package the WoT request
 	    and transfer it over the secure channel to the Local Intermediary WoT Servient,
             which in turn can issue requests to the WoT Thing on the local network.
             The local network channel between the Local Intermediary WoT Servient and the WoT Thing can be left unprotected
             (relying purely on the closed nature of the local network),
-            but it is strongly recommended to employ suitable additional security mechanisms 
+            but it is strongly recommended to employ suitable additional security mechanisms
             as described in Section <a href="#wot-client-server-basic"></a> to perform authentication
             and authorization of involved parties (WoT Thing and Local Intermediary WoT Servient),
             as well as to provide confidentiality and integrity of transferred solution data and the TD.
@@ -2734,14 +2734,14 @@ tracking equipment, information about user's preferences in home environment, vi
             </figure>
 
            <p>
-            An alternative security setup for this scenario can use end-to-end security 
+            An alternative security setup for this scenario can use end-to-end security
 	    authentication and authorization.
-            In this case the WoT Consumer would not only need to authenticate and authorize 
+            In this case the WoT Consumer would not only need to authenticate and authorize
 	    itself to the Remote Intermediary WoT Servient,
             but also to the WoT Thing.
             In this case it would need a separate set of security credentials,
             required to successfully authenticate with each party.
-	    The exposed TD should indicate the mechanisms to obtain these credentials, e.g. via OAuth2.          
+	    The exposed TD should indicate the mechanisms to obtain these credentials, e.g. via OAuth2.
           </p>
 
           </section>
@@ -2749,15 +2749,15 @@ tracking equipment, information about user's preferences in home environment, vi
           <section id="wot-client-server-tunnel">
            <h2>Basic Interaction between WoT Thing and WoT Consumer via a Tunnel</h2>
 
-           <p>As an alternative to the use of a split proxy, 
+           <p>As an alternative to the use of a split proxy,
 	   which requires a trusted remote proxy to accept interaction
-           requests on behalf of the WoT Thing, 
+           requests on behalf of the WoT Thing,
 	   a secure tunnel (such as an SSH tunnel) can be set up between the WoT Thing and
-           an endpoint in the cloud.  
+           an endpoint in the cloud.
 	   In order to traverse the NAT the WoT Thing would have to initiate the connection, so
-           in practice this would be a reverse tunnel set up by the "server". 
+           in practice this would be a reverse tunnel set up by the "server".
 	   However, then a port made available by the Thing would be made
-           available directly on the cloud server supporting the tunnel endpoint, 
+           available directly on the cloud server supporting the tunnel endpoint,
 	   possibly mapped to a different port.
 	   The use of a tunnel for NAT traversal is shown in <a href="#wot_client_thing_tunnel"></a>.
            </p>
@@ -2765,48 +2765,48 @@ tracking equipment, information about user's preferences in home environment, vi
               <img src="images/tunnel.png" style="width: 1000px;" />
               <figcaption>WoT Thing and WoT Consumer via Tunnel</figcaption>
             </figure>
-		  
+
            <p>
-           In this configuration the WoT Thing must be responsible for all security, 
+           In this configuration the WoT Thing must be responsible for all security,
 	   including (if necessary) certificates
            appropriate for the tunnel endpoint in the cloud.  i
-	   This implies that the WoT Thing needs to be relatively powerful, 
+	   This implies that the WoT Thing needs to be relatively powerful,
 	   as constrained devices may not be able to support security mechanisms suitable for
-           direct exposure on the Internet.  
+           direct exposure on the Internet.
 	   The WoT Thing would also have to be actively maintained and patched.
-           If the WoT Thing provides a TD, it should use URLs that refer to the tunnel endpoint.  
+           If the WoT Thing provides a TD, it should use URLs that refer to the tunnel endpoint.
 	   This generally means that the port used for the local side of the tunnel
-           should not be used to provide local connections as the certificates will be 
+           should not be used to provide local connections as the certificates will be
 	   incorrect for local connections.
            Instead a separate port (and possibly a separate TD with local URLs) should be provided.
-           </p>	  
+           </p>
            <p>One advantage of this arrangement is that communication is never available in plaintext on either the
-           gateway or the client.  Specifically, the private keys for end-to-end communication between the 
+           gateway or the client.  Specifically, the private keys for end-to-end communication between the
 	   WoT Thing and the WoT Consumer, assuming a secure protocol stack such as HTTP-over-TLS is used, never need to be made
 	   available to either the local gateway or to the cloud portal.
            In other words, this configuration supports end-to-end encrypted communication, and does not rely
            on trusting either the gateway or the cloud portal.
-           Because of this, it is not technically necessary for the tunnel to be over SSH; 
+           Because of this, it is not technically necessary for the tunnel to be over SSH;
 	   a regular IP tunnel would suffice.
 	   </p>
-	   <p>A variation of this is shown in <a href="#wot_client_thing_proxy"></a>.  
+	   <p>A variation of this is shown in <a href="#wot_client_thing_proxy"></a>.
 	   A reverse tunnel is still
-           used here, but terminates in a local port "inside" the cloud portal, 
+           used here, but terminates in a local port "inside" the cloud portal,
 	   that is, the local port is not made visible outside
-	   the cloud portal's firewall.  
+	   the cloud portal's firewall.
 	   A local proxy service then runs inside the cloud portal and provides
-	   a bridge to a secure external network interface.  
+	   a bridge to a secure external network interface.
 	   For example, the protocol from the WoT Thing might be HTTP,
-           which the proxy service could bridge to an external HTTP-over-TLS (HTTPS) network interface.  
+           which the proxy service could bridge to an external HTTP-over-TLS (HTTPS) network interface.
 	   In this case, the
-           tunnel should be encrypted (for example, using SSH) to prevent eavesdropping; 
+           tunnel should be encrypted (for example, using SSH) to prevent eavesdropping;
 	   a regular IP tunnel is not sufficient.
-           Depending on the configuration, 
-           the unencrypted traffic (eg HTTP) may also be visible on the local network.   
+           Depending on the configuration,
+           the unencrypted traffic (eg HTTP) may also be visible on the local network.
 	   In this case, the only protection
            would be from that provided by the local network, eg WPA.
            If such a relatively unprotected local interface is <em>not</em> desirable,
-	   another SSH tunnel can be used between the WoT Thing and the Intermediary WoT Servient, 
+	   another SSH tunnel can be used between the WoT Thing and the Intermediary WoT Servient,
 	   or the WoT Thing can act as
            its own gateway (with the HTTP traffic protected behind a firewall).
            </p>
@@ -2819,7 +2819,7 @@ tracking equipment, information about user's preferences in home environment, vi
            need to be trusted.  This can be mitigated somewhat by using application-level end-to-end object security
            [[COSE17]].
            </p>
-		  
+
             <figure id="wot_client_thing_proxy">
               <img src="images/proxy.png" style="width: 1000px;" />
               <figcaption>WoT Thing and WoT Consumer via HTTP-over-TLS (
@@ -2828,13 +2828,13 @@ HTTPS)/HTTP Proxy</figcaption>
 
            <p>Yet another variant of this approach is shown in <a href="#wot_client_thing_proxy"></a>.
 	   In this variant, the proxy is extended to support caching.
-           This means that the proxy may not always forward requests to the 
+           This means that the proxy may not always forward requests to the
            WoT Thing, but may instead respond on its behalf using stored state.
            </p>
            <p>There are two sub-variants of this approach.
            First, a simple HTTP Proxy can be used that caches responses from the WoT Thing.
            For example, property reads might return an exact copy of an earlier cached payload if only a small
-           amount of time (for some configurable value of "small") 
+           amount of time (for some configurable value of "small")
 	   has elapsed since the last request for that property.
            However, this approach still requires that the WoT Thing be "always on"
            and able to respond as a server in case cached content is not available or has expired.
@@ -2850,10 +2850,10 @@ HTTPS)/HTTP Proxy</figcaption>
            Specifically, the Thing Description indicates which interactions are "properties" that can be "observed".
            The proxy service can "observe" all such properties and maintain copies of their state in the cloud server
            (it is also possible to do this in the gateway, a sub-variant of this pattern).
-           Then when a request comes in to read a property, it can be read from the stored state.  However, the 
+           Then when a request comes in to read a property, it can be read from the stored state.  However, the
            "observe" pattern allows the WoT Thing to send updates on its own schedule, leading to greater power
 	   efficiency.  In addition, the proxy service can see from the Thing Description which network interface
-           methods are "actions" and need to be sent directly to the WoT Thing.  This reduces the need for the 
+           methods are "actions" and need to be sent directly to the WoT Thing.  This reduces the need for the
            WoT Thing to mark interactions as being cacheable or not.
 		    <!--
            The cache functionality can either be combined with the security endpoint proxy or can be instantiated
@@ -2872,12 +2872,12 @@ HTTPS)/HTTP Proxy</figcaption>
          <section>
            <h2>WoT Servient Single-Tenant</h2>
            <p>
-           In previous examples we have considered the Wot Servient as a black box 
-	   exposing a set of WoT Interfaces and Thing Descriptions. 
-	   <a href="#wot_servient-single-tenant"></a> shows the WoT Servient 
-	   (for example consider again a garage door controller device or an Intermediary WoT Servient) 
-	   in more detail with Scripting API support and a couple of scripts running inside a WoT runtime. 
-	   For this case we consider all scripts to be trusted and provisioned 
+           In previous examples we have considered the Wot Servient as a black box
+	   exposing a set of WoT Interfaces and Thing Descriptions.
+	   <a href="#wot_servient-single-tenant"></a> shows the WoT Servient
+	   (for example consider again a garage door controller device or an Intermediary WoT Servient)
+	   in more detail with Scripting API support and a couple of scripts running inside a WoT runtime.
+	   For this case we consider all scripts to be trusted and provisioned
 	   to the device by a single trusted entity (for example by the manufacturer during factory installation).
             </p>
             <figure id="wot_servient-single-tenant">
@@ -2885,58 +2885,58 @@ HTTPS)/HTTP Proxy</figcaption>
               <figcaption>WoT Servient Single-Tenant</figcaption>
             </figure>
             <p>
-            Since all scripts running inside the WoT runtime are considered trusted for this scenario, 
-	    there is no strong need to perform strict isolation between each running script instance. 
-	    However, depending on device capabilities and deployment use case scenario risk level 
-	    it might be desirable to do so. 
-	    For example, if one script handles sensitive privacy-related data and well-audited, 
-	    it might be desirable to separate it from the rest of the script instances to minimize the 
-	    risk of data exposure in case some other script inside WoT gets compromised during the runtime. 
-	    Such isolation can be performed within the WoT Runtime 
+            Since all scripts running inside the WoT runtime are considered trusted for this scenario,
+	    there is no strong need to perform strict isolation between each running script instance.
+	    However, depending on device capabilities and deployment use case scenario risk level
+	    it might be desirable to do so.
+	    For example, if one script handles sensitive privacy-related data and well-audited,
+	    it might be desirable to separate it from the rest of the script instances to minimize the
+	    risk of data exposure in case some other script inside WoT gets compromised during the runtime.
+	    Such isolation can be performed within the WoT Runtime
 	    using platform security mechanisms available on the device.
             </p>
             <p>
             Depending on the device capabilities, the following isolation mechanisms might be available:
             <ul>
-            <li><strong>WoT Runtime enforced isolation.</strong> 
-	    This is the basic isolation provided by the WoT Runtime itself 
-	    and is based on restricting the API exposed to the scripts running within the WoT Runtime. 
+            <li><strong>WoT Runtime enforced isolation.</strong>
+	    This is the basic isolation provided by the WoT Runtime itself
+	    and is based on restricting the API exposed to the scripts running within the WoT Runtime.
 	    The exact set of guarantees depends on the concrete WoT Runtime implementation and might vary.</li>
-            <li><strong>Native OS process-based isolation.</strong> 
-	    This method relies on the underlying native OS to provide basic isolation guarantees 
-	    based on native process isolation. 
-	    The exact set of guarantees depends on capabilities of native OS, 
-	    but it usually includes at least memory and execution content isolation. 
+            <li><strong>Native OS process-based isolation.</strong>
+	    This method relies on the underlying native OS to provide basic isolation guarantees
+	    based on native process isolation.
+	    The exact set of guarantees depends on capabilities of native OS,
+	    but it usually includes at least memory and execution content isolation.
 	    Some other mechanisms like Discretionary Access Controls (DAC) might be also available. </li>
-            <li><strong>Native OS advanced isolation.</strong> 
-	    An OS might also provide a stronger set of measures that can be deployed for process-based isolation. 
-	    Examples of such measures are Mandatory access Control (MACs in all major OSes), 
+            <li><strong>Native OS advanced isolation.</strong>
+	    An OS might also provide a stronger set of measures that can be deployed for process-based isolation.
+	    Examples of such measures are Mandatory access Control (MACs in all major OSes),
 	    OS-level virtualization (i.e. namespaces and containers in Linux), Cryptographic methods etc. </li>
             </ul>
             </p>
             <p>
-            The mechanisms are provided in the order from weakest to the strongest isolation method 
-	    and can be used in combination. 
-	    In order to choose the appropriate mechanism one should study the capabilities of the underlying device, 
-	    as well as evaluate the risk level of particular deployment scenario. 
+            The mechanisms are provided in the order from weakest to the strongest isolation method
+	    and can be used in combination.
+	    In order to choose the appropriate mechanism one should study the capabilities of the underlying device,
+	    as well as evaluate the risk level of particular deployment scenario.
 	    <!--
-	    See Section <a href="#determine-suitable-architecture"></a> for more details on how to evaluate the risk level. 
+	    See Section <a href="#determine-suitable-architecture"></a> for more details on how to evaluate the risk level.
 	    -->
-	    It is also important to note that all isolation mechanisms usually affect performance 
+	    It is also important to note that all isolation mechanisms usually affect performance
 	    and might require non-trivial policy setup and management.
             </p>
             <p>
-            Now if we consider the basic communication scenario between the WoT Consumer 
-	    and the device exposing the WoT Thing described in Section <a href="#wot-client-server-basic"></a> 
-	    from a perspective of script instances running inside WoT Runtime, 
-	    each such instance should be able to have a way to perform mutual authentication 
-	    between itself and a remote WoT Consumer or support a token-based authentication method. 
+            Now if we consider the basic communication scenario between the WoT Consumer
+	    and the device exposing the WoT Thing described in Section <a href="#wot-client-server-basic"></a>
+	    from a perspective of script instances running inside WoT Runtime,
+	    each such instance should be able to have a way to perform mutual authentication
+	    between itself and a remote WoT Consumer or support a token-based authentication method.
 	    However, there are no methods in the WoT Scripting API to perform any such tasks.
-	    Instead the underlying WoT Runtime and protocol bindings handle the required 
-	    security functionality transparently for the WoT scripts. 
-	    <a href="#wot_scripts_security_1"></a> shows how it is done, 
-	    when a WoT Script discovers a new WoT Thing, MyLampThing, 
-	    using the discover() scripting API method, and invokes an action "toggle". 
+	    Instead the underlying WoT Runtime and protocol bindings handle the required
+	    security functionality transparently for the WoT scripts.
+	    <a href="#wot_scripts_security_1"></a> shows how it is done,
+	    when a WoT Script discovers a new WoT Thing, MyLampThing,
+	    using the discover() scripting API method, and invokes an action "toggle".
 
             <figure id="wot_scripts_security_1">
               <img src="images/scripts-security-1.png" style="width: 1000px;" />
@@ -2946,15 +2946,15 @@ HTTPS)/HTTP Proxy</figcaption>
             </p>
 
             <p>
-            <a href="#wot_scripts_security_2"></a> shows handling of security configuration 
-	    during the exposure of a new WoT Thing, MyLampThing. 
-	    Since the security configurations 
-	    (types of authentication and authorization methods and corresponding credentials) 
-	    are not exposed to the WoT Scripts, 
-	    but handled by the WoT Runtime and underlying protocol bindings, 
-	    WoT Scripts must either rely on the WoT Runtime to use the default credentials provisioned to it, 
-	    or indicate the choice of security methods and credentials 
-	    using a name/id tag known to the WoT Runtime.   
+            <a href="#wot_scripts_security_2"></a> shows handling of security configuration
+	    during the exposure of a new WoT Thing, MyLampThing.
+	    Since the security configurations
+	    (types of authentication and authorization methods and corresponding credentials)
+	    are not exposed to the WoT Scripts,
+	    but handled by the WoT Runtime and underlying protocol bindings,
+	    WoT Scripts must either rely on the WoT Runtime to use the default credentials provisioned to it,
+	    or indicate the choice of security methods and credentials
+	    using a name/id tag known to the WoT Runtime.
 
 
             <figure id="wot_scripts_security_2">
@@ -2963,17 +2963,17 @@ HTTPS)/HTTP Proxy</figcaption>
             </figure>
 
             </p>
-            
+
             </section>
 
             <section>
             <h2>WoT Servient Multi-Tenant</h2>
             <p>
-              <a href="#wot_servient-multi-tenant"></a> shows the WoT Servient 
-	      with two different tenants running in two different instances of WoT Runtime. 
-	      There is a no trust relation between different tenants and they can be untrusted. 
-	      Each tenant can have multiple independent WoT scripts running inside their WoT Runtime. 
-	      WoT Runtime core also has a Thing Manager entity that allows installation of scripts 
+              <a href="#wot_servient-multi-tenant"></a> shows the WoT Servient
+	      with two different tenants running in two different instances of WoT Runtime.
+	      There is a no trust relation between different tenants and they can be untrusted.
+	      Each tenant can have multiple independent WoT scripts running inside their WoT Runtime.
+	      WoT Runtime core also has a Thing Manager entity that allows installation of scripts
 	      into the corresponding WoT Runtimes.
             </p>
             <figure id="wot_servient-multi-tenant">
@@ -2981,9 +2981,9 @@ HTTPS)/HTTP Proxy</figcaption>
               <figcaption>WoT Servient Multi-Tenant</figcaption>
             </figure>
             <p>
-            The case of the multi-tenant servient with a possibility to install WoT Scripts remotely 
-	    into WoT Runtimes brings an additional set of threats that must be taken into account: 
-	    <a>WoT Script Management Interface Threat</a>, 
+            The case of the multi-tenant servient with a possibility to install WoT Scripts remotely
+	    into WoT Runtimes brings an additional set of threats that must be taken into account:
+	    <a>WoT Script Management Interface Threat</a>,
 	    <a>WoT Untrusted Script Threat - Script Compromise</a>,
 	    <a>WoT Untrusted Script Threat - Runtime Compromise</a>,
 	    <a>WoT Untrusted Script Threat - Authenticity</a>,
@@ -2996,21 +2996,21 @@ HTTPS)/HTTP Proxy</figcaption>
 	    <a>WoT Untrusted Script Threat - DoS</a>.
             </p>
             <p>
-            In order to address these threats one should utilize the strongest isolation method available 
-	    on the device to separate different WoT Runtimes. 
-	    The isolation should cover execution context, 
+            In order to address these threats one should utilize the strongest isolation method available
+	    on the device to separate different WoT Runtimes.
+	    The isolation should cover execution context,
 	    runtime memory, local storage and resource allocation between different WoT Runtimes.
             </p>
             <p>
-            In addition the Thing Manager should have a reliable way to distinguish 
-	    between different tenants in order to securely manage provisioning and updates of scripts 
-	    into the corresponding WoT Runtime. 
-	    This can be achieved by authenticating the tenant 
+            In addition the Thing Manager should have a reliable way to distinguish
+	    between different tenants in order to securely manage provisioning and updates of scripts
+	    into the corresponding WoT Runtime.
+	    This can be achieved by authenticating the tenant
 	    using one of the authentication methods described in Section <a href="#wot-client-server-basic"></a>.
             </p>
             <p>
-            Also each tenant inside the WoT runtime requires a different set of security credentials 
-	    to be provisioned and made accessible for its scripts. 
+            Also each tenant inside the WoT runtime requires a different set of security credentials
+	    to be provisioned and made accessible for its scripts.
 	    These credentials should be also strictly isolated between different tenants.
             </p>
             </section>
@@ -3019,20 +3019,20 @@ HTTPS)/HTTP Proxy</figcaption>
     <section id="security-validation">
       <h1 id="e-security-validation">Security Validation</h1>
           <p>This section provides guidance on how a WoT System implementation can be
-          tested in order to evaluate its security and privacy.  
-          A <a href="https://github.com/w3c/wot-security-best-practices/">WoT Security Best Practices</a> 
-          document describes best practices for securing WoT implementations.  
+          tested in order to evaluate its security and privacy.
+          A <a href="https://github.com/w3c/wot-security-best-practices/">WoT Security Best Practices</a>
+          document describes best practices for securing WoT implementations.
           This section focuses on systems that follow those best practice since systems that do
           not generally will have known vulnerabilities and testing
           to reveal them would be redundant.
           </p>WoT Systems can consist both of purpose-built components and pre-existing
-          components.  
+          components.
           Purpose-built WoT components should be
-          implemented using WoT security best practices.  
-          However, pre-existing systems may also have WoT Thing Descriptions written 
-          for them so that other WoT components can interface with them.  
+          implemented using WoT security best practices.
+          However, pre-existing systems may also have WoT Thing Descriptions written
+          for them so that other WoT components can interface with them.
           Such "retrofitted" pre-existing components
-          may also have pre-existing security weaknesses and vulnerabilities.  
+          may also have pre-existing security weaknesses and vulnerabilities.
           Security testing may reveal these
           as well, but it should be understood that describing a network interface
           using a WoT Thing Description does not guarantee that it will be secure: in order
@@ -3046,23 +3046,23 @@ HTTPS)/HTTP Proxy</figcaption>
       <h2>Testing Goals</h2>
           <p>
           The goal of WoT security testing is to find security vulnerabilities in
-          the implementation of WoT components, so they can be mitigated.  
+          the implementation of WoT components, so they can be mitigated.
           This can be broadened to finding weaknesses (potential vulnerabilities)
           since mitigating both actual and potential vulnerabilities is
           sufficient to secure a system, and in general it can be hard to determine
           if a weakness is exploitable.
-          It is not possible in general to prove the converse, 
-          that a WoT component is secure (that is, that it has no vulnerabilities).  
+          It is not possible in general to prove the converse,
+          that a WoT component is secure (that is, that it has no vulnerabilities).
           However, thorough security testing can at least ensure
-          that there are no obvious (easily discoverable) weaknesses or 
+          that there are no obvious (easily discoverable) weaknesses or
           vulnerabilities in an implementation.
           </p><p>
           Furthermore, the goal of security testing for an implementor is to identify the existence of
           weaknesses, not to exploit them to break into or manipulate a system.
-          For an implementor, the priority after discovery of a weakness is to 
+          For an implementor, the priority after discovery of a weakness is to
           implement a mitigation to prevent it from being exploited,
-          not to actually find or create an exploit and use it.  
-          Not all weaknesses are vulnerabilities.  
+          not to actually find or create an exploit and use it.
+          Not all weaknesses are vulnerabilities.
           Fixing actual (exploitable) vulnerabilities should have a higher priority than
           simple weaknesses,
           so an implementor may want to also determine which weaknesses are
@@ -3079,15 +3079,15 @@ HTTPS)/HTTP Proxy</figcaption>
     </section>
     <section>
       <h2>Best Practices</h2>
-      <p>Before beginning security testing, it is useful to determine if the components 
+      <p>Before beginning security testing, it is useful to determine if the components
       of the system being tested have been implemented following good and up-to-date security practices.
-      What we really want to do is identify systems that use known insecure practices, 
+      What we really want to do is identify systems that use known insecure practices,
       for which vulnerabilities are known. Many times such vulnerabilities will be
       obvious from the WoT Thing Description, and can be identified with simple tools.
       </p><p>
       As an example, suppose a WoT Thing combines "basic" authentication with plain (unencrypted) HTTP.
       In this case the username and password can be easily recovered from the header
-      information of the unencrypted HTTP request by an eavesdropper with access to the 
+      information of the unencrypted HTTP request by an eavesdropper with access to the
       network traffic, for example by code running in a compromised router or by someone
       who has broken WiFi encryption.
       </p><p>
@@ -3096,7 +3096,7 @@ HTTPS)/HTTP Proxy</figcaption>
       </p><p>
       Hiding the Thing Descriptions of such systems is not really a solution: this is
       equivalent to security by obscurity which is widely considered to be ineffective.
-      Generally, the "secret information" 
+      Generally, the "secret information"
       allowing access to a system should be in the form of easily modifiable keys,
       not engineering details which, once revealed, cannot be easily changed.
       However, certainly mitigating obvious vulnerabilities
@@ -3110,7 +3110,7 @@ HTTPS)/HTTP Proxy</figcaption>
       network interfaces of a Thing. A Thing may have a Thing Description that describes
       a network interface that follows best practices and may pass all the additional
       security tests described below on that interface, but may still have an insecure
-      backdoor (additional network interface) not described in the Thing Description.  
+      backdoor (additional network interface) not described in the Thing Description.
       It is the implementor's
       responsibility to secure <em>all</em> network interfaces, even if the Thing Description is
       subsetted.  Note that there are valid reasons to subset a Thing Description,
@@ -3127,44 +3127,44 @@ HTTPS)/HTTP Proxy</figcaption>
     <section>
       <h2>Functional Security Testing</h2>
       <p>Functional testing checks that a WoT Thing implements the interactions
-      described in its Thing Description. This includes whether or not it 
-      responds to all URLs given and accepts and returns data as specified 
+      described in its Thing Description. This includes whether or not it
+      responds to all URLs given and accepts and returns data as specified
       in the data schemas given in the Thing Description for each interaction.
       </p><p>
-      Functional testing should also check that all security mechanisms 
+      Functional testing should also check that all security mechanisms
       described in the Thing Description are implemented properly.
-      Does the Thing do what the Thing Description says it does in terms of security, 
+      Does the Thing do what the Thing Description says it does in terms of security,
       and only that?
       Does the Thing Description accurately describe the security mechanisms
       used by the Thing?
       Do all interactions accept authorized accesses, and reject accesses
       that do not provide correct authentication and authorization information?
       </p><p>
-      Again, there can be both purpose-built and pre-existing devices described 
+      Again, there can be both purpose-built and pre-existing devices described
       by a Thing Description.  A Thing Description needs to accurately describe
-      the security behavior and requirements in both cases. 
+      the security behavior and requirements in both cases.
       </p>
     </section>
     <section>
       <h2>Adversarial Security Testing</h2>
-      <p>Adversarial security testing (also known as penetration testing or pentesting) 
+      <p>Adversarial security testing (also known as penetration testing or pentesting)
       includes various checks that can be done in order
       to find weaknesses in the target device or service and determine their
       severity and exploitability (that is, whether they are actual vulnerabilities).
       On a high level adversarial testing consists of three stages, which
       are often applied iteratively:
       <ol>
-          <li><strong>Information gathering:</strong> 
+          <li><strong>Information gathering:</strong>
           Required information is collected about the attack target.
           <li><strong>Weakness discovery:</strong>
           An attack target is analyzed and weaknesses are found.
-          <li><strong>Exploitation generation:</strong> 
+          <li><strong>Exploitation generation:</strong>
           An attempt is made to convert weaknesses into vulnerabilities
           by discovering or designing exploits.
       </ol>
-      <p>Exploits are designed to achieve a desired outcome, 
+      <p>Exploits are designed to achieve a desired outcome,
       such as privilege escalation, authorization bypass, denial of service, and other goals.
-      A successful exploit of one vulnerability 
+      A successful exploit of one vulnerability
       may be used to expose other weaknesses and allow them in turn to be exploitable.
       Conversely, a weakness may be prevented from exploitation by a mitigation that
       prevents the class of exploit to which it is vulnerable.
@@ -3174,14 +3174,14 @@ HTTPS)/HTTP Proxy</figcaption>
       to help guide this activity. One example of such guide is the "Web Service
       Security Testing Cheat Sheet" [[Owa18]] written by the Open Web Application
       Security Project (OWASP).  Generally speaking, WoT components can be treated
-      as web services for the purposes of security testing, especially if they use HTTP.  
+      as web services for the purposes of security testing, especially if they use HTTP.
       However, WoT components also
-      have some additional considerations, 
+      have some additional considerations,
       for example local access while using HTTP-over-TLS (HTTPS), or
       use of non-HTTP protocols such as CoAP or MQTT.
       </p><p>
       For the purposes of WoT security testing we will focus on Stage 2,
-      <em>Weakness Discovery</em>.  
+      <em>Weakness Discovery</em>.
       Weakness discovery can be broken down into a combination of
       static weakness discovery and runtime weakness discovery.
       </p><p>
@@ -3190,21 +3190,21 @@ HTTPS)/HTTP Proxy</figcaption>
       documents much of the information needed). Generally speaking, trying to achieve
       security through obscurity is not feasible or desirable, so for testing we should assume the
       attacker knows as much about the system as the implementor.
-      Also, since our goal is to test the 
+      Also, since our goal is to test the
       security of the components of a WoT System, not actually break into it,
       we also will not focus on Stage 3.
-      However, an exploitable vulnerability has a higher priority for correction 
+      However, an exploitable vulnerability has a higher priority for correction
       than a simple weakness for which no exploit is (yet) known, so this information
       is still useful to prioritize mitigation.
       </p>
-      
+
     <section id="static-weakness-discovery">
     <h3>Static Weakness Discovery</h3>
       <p>Static weakness discovery typically requires an access to the target's source code,
       and therefore is not always possible to perform for a black-box penetration tester.
       However, since a WoT Thing developer or WoT Service provider have the access,
       they are strongly encouraged to use the below methods to check for weaknesses (potential
-      vulnerabilities) in their components as part of white-box testing. 
+      vulnerabilities) in their components as part of white-box testing.
       Static weakness discovery is very well supported and automated.
       Many tools are available, so after an initial setup phase,
       it should add little overhead to the WoT component development and release process.
@@ -3214,17 +3214,17 @@ HTTPS)/HTTP Proxy</figcaption>
       <h4>Static Code Analysis</h4>
       <p>The most common example of static weakness discovery is usage of a
       static code analyzer tool that is able to parse a program's code and
-      highlight potential development mistakes and insecure practices, 
+      highlight potential development mistakes and insecure practices,
       such usage of insecure functions or libraries,
       forgotten boundary checks when operating on arrays, and many other sources
       of security weakness.
       Usually the output of such a tool is in the form of a report that
       needs to be manually triaged to determine if each reported issue is a false positive
-      or a real mistake. 
-      While static development tools are constantly improving and 
+      or a real mistake.
+      While static development tools are constantly improving and
       over time are able
-      to offer better and better coverage, lower false positive rates, 
-      and discover more weaknesses, 
+      to offer better and better coverage, lower false positive rates,
+      and discover more weaknesses,
       it is important to remember that these tools (as any others) do
       not guarantee finding all weaknesses in the scanned component.
       Other methods should be used to complement static analysis.</p>
@@ -3245,18 +3245,18 @@ HTTPS)/HTTP Proxy</figcaption>
       <h4>Known vulnerability checking</h4>
       <p>In addition to checking for development mistakes in new code,
       it is also important to check that programs do not include
-      vulnerable third-party libraries or utilities with known weaknesses or 
+      vulnerable third-party libraries or utilities with known weaknesses or
       vulnerabilities. There are many tools developed
       for this purpose and on a high level they work by scanning executable binaries
       (or source code for non-compiled languages) or application packages in a search
       for vulnerable components, such as old versions of libraries that are vulnerable
-      to known attacks. 
+      to known attacks.
       The information about weaknesses and vulnerabilities usually comes from
       the open NIST database which is updated regularly since
-      new weaknesses and vulnerabilities are reported all the time.  
+      new weaknesses and vulnerabilities are reported all the time.
       This also implies that the analysis should be repeated regularly, ideally
       daily and as part of an automated build process, using the latest version
-      of the weakness and vulnerability database.  As new weaknesses, vulnerabilities,  
+      of the weakness and vulnerability database.  As new weaknesses, vulnerabilities,
       and exploits are found, components may then have to be updated to mitigate any
       new weaknesses and vulnerabilities.
       </p>
@@ -3277,13 +3277,13 @@ HTTPS)/HTTP Proxy</figcaption>
       weakness discovery does not require access to the source code or
       compiled binaries of a component, but merely an ability to access a
       component's exposed interfaces (especially network-facing interfaces)
-      and/or an ability to observe and modify the protocol and the 
+      and/or an ability to observe and modify the protocol and the
       component's communication with other components.
       </p><p>
-      The goal of runtime weakness discovery is to find an interface input 
+      The goal of runtime weakness discovery is to find an interface input
       or protocol modification that leads to unintended behavior, such as component
       deadlock or crash.  Even if a crash is not the desired outcome for an attacker,
-      a crash is also an indication of a weakness, such as a 
+      a crash is also an indication of a weakness, such as a
       lack of input validation, that can be used in more sophisticated exploits.
       Of course finding inputs that cause such problems and mitigating them
       also increases the overall robustness and quality of the code.
@@ -3301,7 +3301,7 @@ HTTPS)/HTTP Proxy</figcaption>
       <h4>Fuzz Testing</h4>
       <p>Fuzz testing is one of the most well known and used runtime weakness
       discovery methods. It is well-automated, many tools exist for common
-      protocols and payloads.  
+      protocols and payloads.
       It is a very powerful method for weakness discovery.
       Fuzz testing works by generating (randomly or pattern-based) highly
       varied input for a specific network exposed interface or protocol payload,
@@ -3312,19 +3312,19 @@ HTTPS)/HTTP Proxy</figcaption>
 
       <p>The biggest challenge with fuzz testing is usually to be able to
       generate the randomized input in a form that is still "correct enough"
-      that it does not get discarded by the lower layers of software or network stack. 
-      For example, if the fuzz testing goal is to test how a network-enabled thermostat 
+      that it does not get discarded by the lower layers of software or network stack.
+      For example, if the fuzz testing goal is to test how a network-enabled thermostat
       processes numeric values on its temperature setting HTTP-exposed interface,
       it is important that fuzzed requests have valid HTTP headers, body
       structure, etc. This way the requests will get delivered all the way
-      to the high-level logic inside the device runtime 
+      to the high-level logic inside the device runtime
       and will not discarded by lower-level HTTP message validation
       and processing components.
       </p>
 
       <p><strong>Examples of tools:</strong>
       There are numerous tools exists for fuzzing
-      HTTP(S)-exposed interfaces. 
+      HTTP(S)-exposed interfaces.
       Examples include Burp Suite [[Burp]], Wfuzz [[Wfuzz]], and Wapiti [[wapiti]].
       Newer protocols, like COAP(S) and MQTT(S), have considerably fewer tools
       available.  However some do exist.
@@ -3336,10 +3336,10 @@ HTTPS)/HTTP Proxy</figcaption>
       <h4>Protocol Analysis</h4>
       <p>In addition to automated Fuzz testing, one might be able to discover
       weaknesses by manually analyzing protocol elements such as
-      headers, payload, and attributes. 
-      For example, an analyst might look for the use of older encryption 
+      headers, payload, and attributes.
+      For example, an analyst might look for the use of older encryption
       or authentication algorithms, or the use of insecure combinations of protocol options.
-      While the actual protocol analysis is a manual process, 
+      While the actual protocol analysis is a manual process,
       many tools exist to capture the protocol traffic, parse it
       according to the protocol, and present it to the analyst in an organized fashion.
 
@@ -3352,14 +3352,14 @@ HTTPS)/HTTP Proxy</figcaption>
       <p>There are many tools available that attempt to perform runtime
       testing for known vulnerabilities. They usually operate
       by attempting to run a known set of exploits or weakness trigger inputs
-      against the target and report the outcomes. 
+      against the target and report the outcomes.
       Such tools should be used in combination with other testing tools
       in order to obtain a more complete runtime weakness and vulnerability discovery result.
       </p>
 
       <p><strong>Examples of tools:</strong> While many different vulnerability
       scanners exist, some specifically target web applications and web server
-      service vulnerabilities and are therefore more focused. 
+      service vulnerabilities and are therefore more focused.
       Examples include w3af [[w3af]],
       the Burp vulnerability scanner [[Burp]], Nikto [[Nikto]], and WATOBO [[WATOBO]].
       </p>
@@ -3375,7 +3375,7 @@ HTTPS)/HTTP Proxy</figcaption>
         used by an attacker to achieve particular attack end goals,
         such as privilege escalation, authorization bypass, denial of service, and so on.
         This step can help to prioritize the order in which weaknesses must be mitigated.
-        Developers should fix the most easily exploitable vulnerabilities first and 
+        Developers should fix the most easily exploitable vulnerabilities first and
         then continuing with others in decreasing level of severity or probability of
         exploitation.
         Some tools mentioned in section <a href="#protocol-analysis"></a> can be used to test
@@ -3389,7 +3389,7 @@ HTTPS)/HTTP Proxy</figcaption>
         only be weakly exploitable, but may still play
         an important role in the attacker exploitation chain as a stepping stone towards
         the end exploitation goal.
-        Therefore, it is strongly encouraged to fix or mitigate all 
+        Therefore, it is strongly encouraged to fix or mitigate all
         weaknesses discovered in analyzed components.</p>
     </section>
     </section>
@@ -3403,7 +3403,7 @@ HTTPS)/HTTP Proxy</figcaption>
       and budget (for non-free tools).  Also the testing procedure will be different for
       purpose-built devices and services vs. pre-existing devices and services.</p>
       <ol>
-      <li><strong><a href="#static-weakness-discovery">Static Weakness Discovery</a></strong> 
+      <li><strong><a href="#static-weakness-discovery">Static Weakness Discovery</a></strong>
         <ol>
         <li><strong><a href="#static-code-analysis">Static Code Analysis:</a></strong>
         If source code is available, a static code checker should be used to check
@@ -3414,50 +3414,50 @@ HTTPS)/HTTP Proxy</figcaption>
         </li>
         </ol>
       </li>
-      <li><strong><a href="#runtime-weakness-discovery">Runtime Weakness Discovery</a></strong> 
-        appropriate tools 
+      <li><strong><a href="#runtime-weakness-discovery">Runtime Weakness Discovery</a></strong>
+        appropriate tools
         such as <a href="#fuzz-testing">Fuzz Testing</a>,
         <a href="#protocol-analysis">Protocol Analysis</a>,
         and <a href="#vulnerability-scanners">Vulnerability Scanners</a>
         can be discover problems even when only the network interface is
         available, and are complementary to other kinds of checks.
      </li>
-     <li><strong><a href="#exploitation">Exploitation Analysis</a></strong> 
+     <li><strong><a href="#exploitation">Exploitation Analysis</a></strong>
         This can be used to prioritize which weaknesses and vulnerabilities should be addressed
         first or whether a given vulnerable system can even be used in a given
-        environment. 
+        environment.
      </li>
-     </ol> 
+     </ol>
      <p>Ideally, security testing should be integrated into the development process
      and all discovered weaknesses addressed as soon as possible.  If this is
      not possible, weaknesses should be prioritized based on the threat
      model and potential for exploitation and addressed in priority order.
      </p>
-    </section> 
-            
+    </section>
+
     <section>
     <h2>Suggested Testing Frequency</h2>
         <p>The actual detailed test procedure depends on the type of activity, the WoT
-        device setup and the actual test tool used. 
+        device setup and the actual test tool used.
         However, below are our general recommendations
         for the frequency of different testing activities:</p>
         <ol>
-        <li><strong><a href="#static-weakness-discovery">Static Weakness Discovery</a></strong> 
+        <li><strong><a href="#static-weakness-discovery">Static Weakness Discovery</a></strong>
         should be done regularly,
         ideally integrated into the development work flow for a WoT component.
         This is important, since any even small code changes can introduce
-        development mistakes, or alternatively new weaknesses can be 
-        discovered in the libraries that a program depends on.  
+        development mistakes, or alternatively new weaknesses can be
+        discovered in the libraries that a program depends on.
         New weaknesses and vulnerabilities
         are discovered in existing libraries almost daily.
         </li>
-        <li><strong><a href="#runtime-weakness-discovery">Runtime Weakness Discovery</a></strong> 
+        <li><strong><a href="#runtime-weakness-discovery">Runtime Weakness Discovery</a></strong>
         should be also done on a regular basis, for example for each major release
         or development milestone.
         </li>
-        <li><strong><a href="#exploitation">Exploitation Analysis</a></strong> 
+        <li><strong><a href="#exploitation">Exploitation Analysis</a></strong>
         should be done occasionally,
-        whenever possible.  
+        whenever possible.
         It is the most time and resource consuming
         activity, often requires external resources with specialized knowledge,
         and cannot in general be automated.
@@ -3485,7 +3485,7 @@ HTTPS)/HTTP Proxy</figcaption>
       planning security testing and mitigations.
       </p>
 </section>
-   
+
     </section>
 </section>
 
@@ -3493,8 +3493,8 @@ HTTPS)/HTTP Proxy</figcaption>
       <h1 id="e-terminology">Terminology</h1>
 
       <p>
-        Please refer to  
-	[[WoT-Architecture]] 
+        Please refer to
+	[[WoT-Architecture]]
 	for definitions of the following terms used in this document: WoT Consumer,
     WoT Thing, WoT Servient, WoT Protocol Binding, WoT Binding Templates, WoT Intermediary,
     WoT Thing Directory, WoT Thing Description, Exposed Thing, WoT Interface, WoT Runtime, and WoT Scripting API.
@@ -3515,13 +3515,13 @@ HTTPS)/HTTP Proxy</figcaption>
       for the following terms:
       <dl>
           <dt>Vulnerability:</dt><dd>
-           Any weakness in software that could be exploited to violate a system or the information 
-           it contains 
+           Any weakness in software that could be exploited to violate a system or the information
+           it contains
            [[ITUx1500]].
           </dd>
           <dt>Weakness:</dt><dd>
-          A shortcoming or imperfection in the software code, design, architecture, or deployment that, 
-          could, at some point become a vulnerability, 
+          A shortcoming or imperfection in the software code, design, architecture, or deployment that,
+          could, at some point become a vulnerability,
           or contribute to the introduction of other vulnerabilities
           [[ITUx1500]].
           </dd>
@@ -3537,7 +3537,7 @@ HTTPS)/HTTP Proxy</figcaption>
       <section id="changes-from-second-release">
         <h2 id="e-changes-from-second-release">Changes from Second Release</h2>
         <ul>
-        <li>Addition of references to published versions of 
+        <li>Addition of references to published versions of
             the [[WoT-Architecture]], [[WoT-Thing-Description]],
             [[WoT-Binding-Templates]], and
             [[WoT-Scripting-API]] documents,
@@ -3554,8 +3554,8 @@ HTTPS)/HTTP Proxy</figcaption>
             This change was made to avoid
             confusion with the "considerations" sections of individual
             WoT documents.</li>
-        <li>Revision and clarification of the attack surfaces 
-            of a WoT System described in  
+        <li>Revision and clarification of the attack surfaces
+            of a WoT System described in
             <a href="#wot-threat-model-attack-surfaces"></a>.</li>
         <li>Empty section for <em>Secure Practices for Thing Directory
             Interaction Protocols</em> was removed.</li>
@@ -3573,7 +3573,7 @@ HTTPS)/HTTP Proxy</figcaption>
       <section id="changes-from-First-release">
         <h2 id="e-changes-from-first-release">Changes from First Release</h2>
         <ul>
-        <li>Replace inline description of W3C Patent Policy with link to 
+        <li>Replace inline description of W3C Patent Policy with link to
             <a href="https://www.w3.org/Consortium/Patent-Policy/">external document</a>.</li>
         <li>Added <a href="#wot-device-lifecycle"></a> describing the states and
             transitions of a device throughout its lifetime.</li>
@@ -3581,7 +3581,7 @@ HTTPS)/HTTP Proxy</figcaption>
         <li>Expanded and clarified role and threat definitions in
             <a href="#wot-threat-model"></a>.</li>
         <li>Added WoT Thing Directory to items (currently) out of scope.</li>
-        <li>Added Side Channel threat to 
+        <li>Added Side Channel threat to
             <a href="#scenario-1-home-environment"></a>.</li>
         <li>Added <a href="#scenario-2-business-corporate-environment"></a>
             describing threats in an office building environment.</li>

--- a/index.html
+++ b/index.html
@@ -333,13 +333,6 @@
                   , date: "1999"
                   , pages: "175-185"
                 },
-                "Vol00": {
-                  authors: ["J. Vollbrecht", "et al."]
-                  , href: "https://tools.ietf.org/rfc/rfc2904.txt"
-                  , title: "AAA Authorization Framework"
-                  , publisher: "IETF RFC 2904"
-                  , date: "Aug. 2000"
-                },
                 "Yeg11": {
                   authors: ["S. Yegge"]
                   , href: "https://plus.google.com/+RipRowan/posts/eVeouesvaVX"
@@ -2132,7 +2125,7 @@ tracking equipment, information about user's preferences in home environment, vi
       <li>[[Sch14]] - <cite>The Internet of Things Is Wildly Insecure — And Often Unpatchable</cite></li>
       <li>[[Sch99]] - <cite>Breaking Up Is Hard To Do: Modeling Security Threats for Smart Cards</cite></li>
       <li>[[RFC7252]] - <cite>The Constrained Application Protocol (CoAP)</cite></li>
-      <li>[[Vol00]] - <cite>AAA Authorization Framework</cite></li>
+      <li>[[RFC2904]] - <cite>AAA Authorization Framework</cite></li>
       <li>[[Yeg11]] - <cite>Stevey's Google Platforms Rant</cite></li>
       </ul>
     </p><p class="ednote" title="Use global database for RFC references">

--- a/index.html
+++ b/index.html
@@ -67,12 +67,6 @@
                 , publisher: "OCF"
                 , date: "June 2017"
                 },
-                "JWT15": {
-                  href: "https://tools.ietf.org/html/rfc7519"
-                , title: "JSON Web Token (JWT)"
-                , publisher: "IETF"
-                , date: "May 2015"
-                },
                 "CBOR17": {
                   href: "https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf"
                 , title: "CBOR Web Token (CWT)"
@@ -2469,7 +2463,7 @@ tracking equipment, information about user's preferences in home environment, vi
 	    of authorization), the following methods can be used instead:
             <ul>
             <li><strong>OAuth 2.0-based access tokens.</strong> These tokens follow the JSON Web Token (JWT)
-		    format defined in RFC 7519 [[JWT15]] and should used according to the suggestions by
+		    format defined in [[RFC7519]] and should used according to the suggestions by
 		    the IETF Authentication and Authorization for Constrained Environments (ACE)
 		    specification draft [[IETFACE]].
 		    These are recommended for devices that are able to use the HTTP protocol and

--- a/index.html
+++ b/index.html
@@ -80,12 +80,6 @@
                 , publisher: "OCF"
                 , date: "June 2017"
                 },
-		"JWE15": {
-                  href: "https://tools.ietf.org/html/rfc7516"
-                , title: "JSON Web Encryption (JWE)"
-                , publisher: "IETF"
-                , date: "May 2015"
-                },
 		"JWS15": {
                   href: "https://tools.ietf.org/html/rfc7515"
                 , title: "JSON Web Signature (JWS)"
@@ -2414,7 +2408,7 @@ tracking equipment, information about user's preferences in home environment, vi
 		     JSON, [[JWS15]] provides a guideline for expressing digital signatures or MACs as well as related
 		     security metadata using JSON-based data structures. [[RFC9052]] does the same for CBOR.</li>
                  <li>If confidentiality is desired for exchanged application data, then encrypt WoT objects using well-known
-		     encryption primitives. For data expressed in JSON, [[JWE15]] provides a guideline for expressing
+		     encryption primitives. For data expressed in JSON, [[RFC7516]] provides a guideline for expressing
 	             encrypted data as well as related security metadata using JSON-based data structures. [[RFC9052]] does
 	             the same for CBOR. Moreover the following is important here:
 		     <ul>


### PR DESCRIPTION
Having a look at the document, I noticed that a lot of the IETF references were outdated and/or could be replaced with pointers to the published RFCs.

Since my editor removes trailing whitespace on saving, I also ~~more or less accidentally~~ cleaned up the document of excess whitespace, but decided to keep these changes in to further increase the document's maintainability. There also was a strange `IMAGES` file that seemed to have no real purpose but caused problems on my system – I hope removing that one is also okay.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-security/pull/216.html" title="Last updated on Feb 28, 2023, 5:22 PM UTC (0d10aa7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security/216/802fee3...JKRhb:0d10aa7.html" title="Last updated on Feb 28, 2023, 5:22 PM UTC (0d10aa7)">Diff</a>