### PR TITLE
Remove Editor's note on RFC references

### DIFF
--- a/index.html
+++ b/index.html
@@ -2053,10 +2053,6 @@ tracking equipment, information about user's preferences in home environment, vi
       <li>[[RFC2904]] - <cite>AAA Authorization Framework</cite></li>
       <li>[[Yeg11]] - <cite>Stevey's Google Platforms Rant</cite></li>
       </ul>
-    </p><p class="ednote" title="Use global database for RFC references">
-          Should use references from global ReSpec bibliography whenever possible,
-          rather than local bibliographic entries.
-    </p>
   </section>
 
   <section id="security-mitigations">

--- a/index.html
+++ b/index.html
@@ -2023,6 +2023,7 @@ tracking equipment, information about user's preferences in home environment, vi
           Also, we don't necessarily need all of these, and may need others not listed.
     </p><p>
       Additional references:
+      </p>
       <ul>
       <li>[[RFC9176]] - <cite>CoRE Resource Directory</cite></li>
       <li>[[Bel89]] - <cite>Security Problems in the TCP-IP Protocol Suite</cite></li>


### PR DESCRIPTION
After the merging of #216, an Editor's note in the document regarding RFC references has become obsolete. This PR simply removes the note in question.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-security/pull/218.html" title="Last updated on Mar 13, 2023, 12:19 PM UTC (1d0e68f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security/218/66d919a...JKRhb:1d0e68f.html" title="Last updated on Mar 13, 2023, 12:19 PM UTC (1d0e68f)">Diff</a>