### PR TITLE
Fix OSCORE reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -2480,8 +2480,7 @@ tracking equipment, information about user's preferences in home environment, vi
 	    a non-(D)TLS protected channel), then authenticity and confidentiality of the transferred data
 	    can be implemented separately on the application layer.
 	    The recommended method for doing this in resource constrained environments is to use the
-	    Object Security of CoAP (OSCoAP) method described in the IETF Object Security of CoAP (OSCoAP)
-	    specification draft [[OSCOAP17]].
+      Object Security for Constrained RESTful Environments (OSCORE) method described in [[RFC8613]].
             </p>
             <p>
             The scenario shown in <a href="#wot_client_thing_basic_2"></a> is similar but with the important


### PR DESCRIPTION
I noticed that #216 did not update the OSCORE reference (RFC 8613) and the name of the method itself (still referring to it as OSCoAP). This PR resolves these issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-security/pull/219.html" title="Last updated on Mar 7, 2023, 4:22 AM UTC (6b79dfd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security/219/66d919a...JKRhb:6b79dfd.html" title="Last updated on Mar 7, 2023, 4:22 AM UTC (6b79dfd)">Diff</a>