### PR TITLE
Add anchors to threats

### DIFF
--- a/index.html
+++ b/index.html
@@ -1286,7 +1286,7 @@
                <th>Asset</th>
                <th>Attack method and pre-conditions</th>
            </tr><tr>
-               <th><dfn>WoT Protocol Binding Threat</dfn></th>
+               <th><dfn id="dfn-wot-protocol-binding-threat">WoT Protocol Binding Threat</dfn></th>
                <td><a>Network Attacker</a>,
                    <a>Malware Developer</a>,
                    <a>Malicious Users</a></td>
@@ -1303,7 +1303,7 @@
                    using protocol binding interfaces with the purpose of
                    compromising protocol binding component and access to all available WoT assets</td>
            </tr><tr>
-               <th><dfn>WoT Interface Threat - Exposed Thing Compromise</dfn></th>
+               <th><dfn id="dfn-wot-interface-threat-exposed-thing-compromise">WoT Interface Threat - Exposed Thing Compromise</dfn></th>
                <td><a>Network Attacker</a>,
                    <a>Malware Developer</a>,
                    <a>Malicious Users</a></td>
@@ -1314,7 +1314,7 @@
                    Same as for <a>WoT Protocol Binding Threat</a> with 
 		   the purpose of compromising an Exposed Thing.</td>
            </tr><tr>
-               <th><dfn>WoT Interface Threat - Unauthorized WoT Interface Access</dfn></th>
+               <th><dfn id="dfn-wot-interface-threat-unauthorized-wot-interface-access">WoT Interface Threat - Unauthorized WoT Interface Access</dfn></th>
                <td><a>Network Attacker</a>,
                    <a>Malware Developer</a>,
                    <a>Malicious Unauthorized Users</a>,
@@ -1329,7 +1329,7 @@
                    Any remote attack method using a WoT Interface
                    with the purpose of obtaining unauthorized access to a WoT asset</td>
            </tr><tr>
-               <th><dfn>WoT DoS Threat</dfn></th>
+               <th><dfn id="dfn-wot-dos-threat">WoT DoS Threat</dfn></th>
                <td><a>Network Attacker</a>,
                    <a>Malware Developer</a>,
                    <a>Malicious Users</a></td>
@@ -1347,7 +1347,7 @@
                    or to disturb the service operation by intentional dropping
                    of all or selective WoT messages</td>
             </tr><tr>
-                <th><dfn>WoT Communication Threat - TD Authenticity</dfn></th>
+                <th><dfn id="dfn-wot-communication-threat-td-authenticity">WoT Communication Threat - TD Authenticity</dfn></th>
                 <td><a>Network Attacker</a>,
                     <a>Malware Developer</a>,
                     <a>Malicious Users</a>,
@@ -1359,7 +1359,7 @@
                     Any attack method on a <a>TD</a> in-transfer with the purpose of its modification,
                     including rolling back to an older version of that <a>TD</a></td>
             </tr><tr>
-                <th><dfn>WoT Communication Threat - TD Confidentiality and Privacy</dfn></th>
+                <th><dfn id="dfn-wot-communication-threat-system-user-data-authenticity">WoT Communication Threat - TD Confidentiality and Privacy</dfn></th>
                 <td><a>Network Attacker</a>,
                     <a>Malware Developer</a>,
                     <a>Malicious Users</a>,
@@ -1371,7 +1371,7 @@
                     Any attack method on TDs in-transfer with the purpose of obtaining unauthorized
                     access to non-public parts of TDs or passively observing public parts of TDs in-transfer</td>
              </tr><tr>
-                 <th><dfn>WoT Communication Threat - System User Data Authenticity</dfn></th>
+                 <th><dfn id="dfn-wot-communication-threat-system-user-data-authenticity">WoT Communication Threat - System User Data Authenticity</dfn></th>
                  <td><a>Network Attacker</a>,
                      <a>Malware developer</a>,
                      <a>Malicious Users</a>,
@@ -1384,7 +1384,7 @@
                      including sequence of received data,
                      its freshness and illegitimate replay</td>
              </tr><tr>
-                 <th><dfn>WoT Communication Threat - System User Data Confidentiality and Privacy</dfn></th>
+                 <th><dfn id="dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy">WoT Communication Threat - System User Data Confidentiality and Privacy</dfn></th>
                  <td><a>Network Attacker</a>,
                      <a>Malware Developer</a>,
                      <a>Malicious Users</a>,
@@ -1396,7 +1396,7 @@
                      Any attack method on solution data in-transfer with the purpose of obtaining
                      unauthorized access</td>
              </tr><tr>
-                 <th><dfn>WoT Communication Threat - Side Channels</dfn></th>
+                 <th><dfn id="dfn-wot-communication-threat-side-channels">WoT Communication Threat - Side Channels</dfn></th>
                  <td><a>Network attacker</a>,
                      <a>Malicious users</a>,
                      <a>Malicious System Provider</a></td>

--- a/static.html
+++ b/static.html
@@ -1,0 +1,3838 @@
+<!DOCTYPE html><html lang="en" xmlns="http://www.w3.org/1999/xhtml"><head><meta charset="utf-8"><meta name="generator" content="ReSpec 25.6.0"><meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"><style>.issue-label{text-transform:initial}.warning>p:first-child{margin-top:0}.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}span.warning{padding:.1em .5em .15em}.issue.closed span.issue-number{text-decoration:line-through}.warning{border-color:#f11;border-width:.2em;border-style:solid;background:#fbe9e9}.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}li.task-list-item{list-style:none}input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}</style>
+    <link rel="stylesheet" href="tablestyle.css">
+    
+    <title>Web of Things (WoT) Security and Privacy Guidelines</title>
+    
+    
+  <style id="respec-mainstyle">@keyframes pop{0%{transform:scale(1,1)}25%{transform:scale(1.25,1.25);opacity:.75}100%{transform:scale(1,1)}}.hljs{background:0 0!important}a abbr,h1 abbr,h2 abbr,h3 abbr,h4 abbr,h5 abbr,h6 abbr{border:none}dfn{font-weight:700}a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}a.bibref{text-decoration:none}.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}@supports not (text-decoration:red wavy underline){.respec-offending-element:not(pre){display:inline-block}.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}}#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}cite .bibref{font-style:normal}code{color:#c63501}th code{color:inherit}a[href].orcid{padding-left:4px;padding-right:4px}a[href].orcid>svg{margin-bottom:-2px}.toc a,.tof a{text-decoration:none}a .figno,a .secno{color:#000}ol.tof,ul.tof{list-style:none outside none}.caption{margin-top:.5em;font-style:italic}table.simple{border-spacing:0;border-collapse:collapse;border-bottom:3px solid #005a9c}.simple th{background:#005a9c;color:#fff;padding:3px 5px;text-align:left}.simple th a{color:#fff;padding:3px 5px;text-align:left}.simple th[scope=row]{background:inherit;color:inherit;border-top:1px solid #ddd}.simple td{padding:3px 10px;border-top:1px solid #ddd}.simple tr:nth-child(even){background:#f0f6ff}.section dd>p:first-child{margin-top:0}.section dd>p:last-child{margin-bottom:0}.section dd{margin-bottom:1em}.section dl.attrs dd,.section dl.eldef dd{margin-bottom:0}#issue-summary>ul,.respec-dfn-list{column-count:2}#issue-summary li,.respec-dfn-list li{list-style:none}details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}details.respec-tests-details>*{padding-right:2em}details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}details.respec-tests-details>ul{width:100%;margin-top:-.3em}details.respec-tests-details>li{padding-left:1em}a[href].self-link:hover{opacity:1;text-decoration:none;background-color:transparent}h2,h3,h4,h5,h6{position:relative}aside.example .marker>a.self-link{color:inherit}h2>a.self-link,h3>a.self-link,h4>a.self-link,h5>a.self-link,h6>a.self-link{border:none;color:inherit;font-size:83%;height:2em;left:-1.6em;opacity:.5;position:absolute;text-align:center;text-decoration:none;top:0;transition:opacity .2s;width:2em}h2>a.self-link::before,h3>a.self-link::before,h4>a.self-link::before,h5>a.self-link::before,h6>a.self-link::before{content:"§";display:block}@media (max-width:767px){dd{margin-left:0}h2>a.self-link,h3>a.self-link,h4>a.self-link,h5>a.self-link,h6>a.self-link{left:auto;top:auto}}@media print{.removeOnSave{display:none}}</style><meta name="description" content="This document provides non-normative guidance on Web of Things (WoT) security and privacy.
+     The Web of Things is descriptive, not prescriptive,
+     and so is generally designed to support the security models and mechanisms of the systems it describes,
+     not introduce new ones.
+     However, a WoT System also has its own unique assets, such as a Scripting API and Thing Descriptions, that
+     need to be protected and also have security and privacy implications."><link rel="canonical" href="https://www.w3.org/TR/wot-security/"><style>var{position:relative;cursor:pointer}var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#000}var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#000;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}</style><script id="initialUserConfig" type="application/json">{
+  "specStatus": "ED",
+  "noRecTrack": "true",
+  "processVersion": 2017,
+  "shortName": "wot-security",
+  "copyrightStart": 2017,
+  "wg": "Web of Things Working Group",
+  "wgURI": "https://www.w3.org/WoT/WG/",
+  "wgPublicList": "public-wot-wg",
+  "edDraftURI": "https://w3c.github.io/wot-security/",
+  "githubAPI": "https://api.github.com/repos/w3c/wot-security",
+  "issueBase": "https://www.github.com/w3c/wot-security/issues",
+  "editors": [
+    {
+      "name": "Elena Reshetova",
+      "w3cid": "99327",
+      "company": "Intel Corp.",
+      "companyURL": "https://www.intel.com/"
+    },
+    {
+      "name": "Michael McCool",
+      "w3cid": "93137",
+      "company": "Intel Corp.",
+      "companyURL": "https://www.intel.com/"
+    }
+  ],
+  "otherLinks": [
+    {
+      "key": "Contributors",
+      "data": [
+        {
+          "value": "In the GitHub repository",
+          "href": "https://github.com/w3c/wot-security/graphs/contributors"
+        }
+      ]
+    },
+    {
+      "key": "Repository",
+      "data": [
+        {
+          "value": "We are on GitHub",
+          "href": "https://github.com/w3c/wot-security/"
+        },
+        {
+          "value": "File a bug",
+          "href": "https://github.com/w3c/wot-security/issues"
+        },
+        {
+          "value": "Contribute",
+          "href": "https://github.com/w3c/wot-security/pulls"
+        }
+      ]
+    }
+  ],
+  "localBiblio": {
+    "AEAD08": {
+      "href": "https://tools.ietf.org/html/rfc5116",
+      "title": "An Interface and Algorithms for Authenticated Encryption",
+      "publisher": "IETF",
+      "date": "January 2008",
+      "id": "aead08"
+    },
+    "CoRE-RD": {
+      "href": "https://tools.ietf.org/html/draft-ietf-core-resource-directory-11",
+      "title": "CoRE Resource Directory",
+      "status": "Internet-Draft",
+      "publisher": "IETF",
+      "date": "03 July 2017",
+      "id": "core-rd"
+    },
+    "Ocf17": {
+      "href": "https://openconnectivity.org/specs/OCF_Security_Specification_v1.0.0.pdf",
+      "title": "The OCF Security Specification, version 1.0.0",
+      "publisher": "OCF",
+      "date": "June 2017",
+      "id": "ocf17"
+    },
+    "JWE15": {
+      "href": "https://tools.ietf.org/html/rfc7516",
+      "title": "JSON Web Encryption (JWE)",
+      "publisher": "IETF",
+      "date": "May 2015",
+      "id": "jwe15"
+    },
+    "JWS15": {
+      "href": "https://tools.ietf.org/html/rfc7515",
+      "title": "JSON Web Signature (JWS)",
+      "publisher": "IETF",
+      "date": "May 2015",
+      "id": "jws15"
+    },
+    "JWT15": {
+      "href": "https://tools.ietf.org/html/rfc7519",
+      "title": "JSON Web Token (JWT)",
+      "publisher": "IETF",
+      "date": "May 2015",
+      "id": "jwt15"
+    },
+    "CBOR17": {
+      "href": "https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf",
+      "title": "CBOR Web Token (CWT)",
+      "status": "Internet-Draft",
+      "publisher": "IETF",
+      "date": "June 2017",
+      "id": "cbor17"
+    },
+    "OSCOAP17": {
+      "href": "https://tools.ietf.org/pdf/draft-ietf-core-object-security-04.pdf",
+      "title": "Object Security of CoAP (OSCOAP)",
+      "status": "Internet-Draft",
+      "publisher": "IETF",
+      "date": "July 2017",
+      "id": "oscoap17"
+    },
+    "COSE17": {
+      "href": "https://tools.ietf.org/html/rfc8152",
+      "title": "CBOR Object Signing and Encryption (COSE)",
+      "publisher": "IETF",
+      "date": "May 2017",
+      "id": "cose17"
+    },
+    "Bel89": {
+      "authors": [
+        "S. Bellovin"
+      ],
+      "href": "https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf",
+      "title": "Security Problems in the TCP-IP Protocol Suite",
+      "publisher": "Computer Communication Review, Vol. 19, No. 2",
+      "pages": "32-48",
+      "date": "April 1989",
+      "id": "bel89"
+    },
+    "Bel13": {
+      "authors": [
+        "S. Bellovin"
+      ],
+      "href": "https://csrc.nist.gov/csrc/media/events/workshop-on-improving-trust-in-the-online-marketpl/documents/presentations/bellovin_ca-workshop2013.pdf",
+      "title": "Web Security in the Real World",
+      "publisher": "Workshop on Improving Trust in the Online Marketplace, NIST",
+      "date": "April 2013",
+      "id": "bel13"
+    },
+    "Ber14": {
+      "authors": [
+        "V. Bertocci"
+      ],
+      "href": "http://www.cloudidentity.com/blog/2014/04/22/authentication-protocols-web-ux-and-web-api/",
+      "title": "Authentication Protocols, Web UX and Web API",
+      "date": "April 2014",
+      "id": "ber14"
+    },
+    "Bor14": {
+      "authors": [
+        "C. Bormann",
+        "et al."
+      ],
+      "href": "https://tools.ietf.org/rfc/rfc7228.txt",
+      "title": "Terminology for Constrained-Node Networks",
+      "publisher": "IETF RFC 7228",
+      "date": "May 2014",
+      "id": "bor14"
+    },
+    "Bru14": {
+      "authors": [
+        "C. Brubaker",
+        "et al."
+      ],
+      "href": "https://www.cs.utexas.edu/~shmat/shmat_oak14.pdf",
+      "title": "Using Frankencerts for Automated Adversarial Testing of Certificate Validation in SSL/TLS Implementations",
+      "publisher": "IEEE Security Privacy",
+      "date": "2014",
+      "pages": "114-129",
+      "id": "bru14"
+    },
+    "Coo13": {
+      "authors": [
+        "A. Cooper",
+        "et al"
+      ],
+      "href": "https://tools.ietf.org/html/rfc6973",
+      "title": "Privacy Considerations for Internet Protocols",
+      "publisher": "IETF RFC 6973 (IAB Guideline)",
+      "date": "July 2013",
+      "id": "coo13"
+    },
+    "Lea05": {
+      "authors": [
+        "P. Leach",
+        "et al"
+      ],
+      "href": "https://tools.ietf.org/html/rfc4122",
+      "title": "A Universally Unique IDentifier (UUID) URN Namespace",
+      "publisher": "IETF RFC 4122",
+      "date": "July 2005",
+      "id": "lea05"
+    },
+    "Dur13": {
+      "authors": [
+        "Z. Durumeric",
+        "et al."
+      ],
+      "href": "https://conferences.sigcomm.org/imc/2013/papers/imc257-durumericAemb.pdf",
+      "title": "Analysis of the HTTPS Certificate Ecosystem",
+      "publisher": "Proc. of the 2013 conference on Internet measurement conference",
+      "date": "October 2013",
+      "id": "dur13"
+    },
+    "Ell00": {
+      "authors": [
+        "C. Ellison",
+        "B. Schneier"
+      ],
+      "href": "https://www.schneier.com/paper-pki.pdf",
+      "title": "Ten Risks of PKI: What You’re not Being Told about Public Key Infrastructure",
+      "publisher": "Computer Security Journal, v 16, n 1,",
+      "date": "2000",
+      "pages": "1-7",
+      "id": "ell00"
+    },
+    "Fu01": {
+      "authors": [
+        "K. Fu",
+        "et al."
+      ],
+      "href": "https://pdos.csail.mit.edu/papers/webauth:sec10.pdf",
+      "title": "Dos and Don’ts of Client Authentication on the Web",
+      "publisher": "Proc. 10th USENIX Security Symposium",
+      "date": "August 2001",
+      "id": "fu01"
+    },
+    "Garcia17": {
+      "authors": [
+        "O. Garcia-Morchon",
+        "S. Kumar",
+        "M. Sethi"
+      ],
+      "title": "State-of-the-Art and Challenges for the Internet of Things Security",
+      "href": "https://datatracker.ietf.org/doc/draft-irtf-t2trg-iot-seccons/",
+      "id": "garcia17"
+    },
+    "Geo12": {
+      "authors": [
+        "M. Georgiev",
+        "et al."
+      ],
+      "href": "https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf",
+      "title": "The Most Dangerous Code in the World: Validating SSL Certificates in Non-Browser Software",
+      "publisher": "Proc. of the 2012 ACM conference on Computer and communications security",
+      "date": "2012",
+      "pages": "38-49",
+      "id": "geo12"
+    },
+    "Gol03": {
+      "authors": [
+        "O. Goldreich"
+      ],
+      "href": "http://www.wisdom.weizmann.ac.il/~oded/foc-sur01.html",
+      "title": "Cryptography and Cryptographic Protocols",
+      "publisher": "Distributed Computing, vol. 16",
+      "pages": "177-199",
+      "date": "2003",
+      "id": "gol03"
+    },
+    "Gre14": {
+      "authors": [
+        "M. Green"
+      ],
+      "href": "https://blog.cryptographyengineering.com/2014/03/19/how-do-you-know-if-rng-is-working/",
+      "title": "How do you know if an RNG is working?",
+      "date": "March 2014",
+      "id": "gre14"
+    },
+    "Gut02": {
+      "authors": [
+        "P. Gutman"
+      ],
+      "href": "https://www.cs.auckland.ac.nz/~pgut001/pubs/notdead.pdf",
+      "title": "PKI: It’s Not Dead, Just Resting",
+      "publisher": "IEEE Computer, vol. 35, no. 8",
+      "date": "Aug. 2002",
+      "pages": "41-49",
+      "id": "gut02"
+    },
+    "Hea13": {
+      "authors": [
+        "M. Hearn"
+      ],
+      "href": "https://googleblog.blogspot.de/2013/02/an-update-on-our-war-against-account.html",
+      "title": "An update on our war against account hijackers",
+      "date": "Feb 2013",
+      "id": "hea13"
+    },
+    "IETFACE": {
+      "title": "IETF Authentication and Authorization for Constrained Environments (ACE)",
+      "href": "https://tools.ietf.org/wg/ace/",
+      "id": "ietface"
+    },
+    "Iic15": {
+      "authors": [
+        "Industrial Internet Consortium"
+      ],
+      "href": "http://www.iiconsortium.org/IIRA.htm",
+      "title": "Industrial Internet Reference Architecture",
+      "date": "June 2015",
+      "id": "iic15"
+    },
+    "IicRA17": {
+      "authors": [
+        "Industrial Internet Consortium"
+      ],
+      "href": "https://www.iiconsortium.org/IIRA.htm",
+      "title": "The Industrial Internet of Things Volume G1: Reference Architecture",
+      "publisher": "IIC:PUB:G1:V1.80:20170131",
+      "date": "Jan 2017",
+      "id": "iicra17"
+    },
+    "IicSF16": {
+      "authors": [
+        "Industrial Internet Consortium"
+      ],
+      "href": "https://www.iiconsortium.org/IISF.htm",
+      "title": "The Industrial Internet of Things Volume G4: Security Framework",
+      "publisher": "IIC:PUB:G4:V1.0:PB:20160926",
+      "date": "Sept 2016",
+      "id": "iicsf16"
+    },
+    "ISF17": {
+      "authors": [
+        "IoT Security Foundation"
+      ],
+      "href": "https://iotsecurityfoundation.org/best-practice-guidelines/",
+      "title": "IoT Security Foundation Best Practice Guidelines",
+      "date": "May 2017",
+      "id": "isf17"
+    },
+    "Jon14": {
+      "authors": [
+        "M. Jones"
+      ],
+      "href": "http://www.niso.org/sites/default/files/stories/2017-08/SP_Jones_JSON_isqv26no3.pdf",
+      "title": "A JSON-Based Identity Protocol Suite",
+      "publisher": "Information Standards Quarterly, vol. 26, no. 3",
+      "date": "2014",
+      "pages": "19–22",
+      "id": "jon14"
+    },
+    "Ken03": {
+      "authors": [
+        "S. Kent",
+        "L. Millet"
+      ],
+      "href": "https://www.nap.edu/read/10656/chapter/1",
+      "title": "Who Goes There? Authentication Through the Lens of Privacy",
+      "publisher": "The National Academies Press, Washington D.C.",
+      "date": "2003",
+      "id": "ken03"
+    },
+    "Lam04": {
+      "authors": [
+        "B. Lampson"
+      ],
+      "href": "https://pdfs.semanticscholar.org/6fe5/ba7a096e391d985e7818fef9d0f0636210a0.pdf",
+      "title": "Computer Security in the Real World",
+      "publisher": "IEEE Computer, vol. 37, no. 6",
+      "date": "June 2004",
+      "pages": "37-46",
+      "id": "lam04"
+    },
+    "Loc05": {
+      "authors": [
+        "H. Lockhart"
+      ],
+      "href": "http://www.oracle.com/technetwork/testcontent/saml-084342.html",
+      "title": "Demystifying SAML",
+      "date": "May 2005",
+      "id": "loc05"
+    },
+    "Mel15": {
+      "authors": [
+        "D. Melzer"
+      ],
+      "href": "https://c.ymcdn.com/sites/www.issa.org/resource/resmgr/journalpdfs/feature0615.pdf",
+      "title": "Securing the Industrial Internet of Things",
+      "date": "June 2015",
+      "id": "mel15"
+    },
+    "Mic17": {
+      "authors": [
+        "Microsoft"
+      ],
+      "href": "https://docs.microsoft.com/en-us/azure/iot-suite/iot-security-architecture",
+      "title": "Internet of Things security architecture",
+      "publisher": "STRIDE threat model for IoT",
+      "date": "Jan 2017",
+      "id": "mic17"
+    },
+    "Moo02": {
+      "authors": [
+        "T. Moors"
+      ],
+      "href": "https://www.csd.uoc.gr/~hy435/material/moors.pdf",
+      "title": "A critical review of End-to-end arguments in system design",
+      "publisher": "Proc. of the IEEE International Conference on Communications",
+      "date": "2002",
+      "id": "moo02"
+    },
+    "Nis15": {
+      "authors": [
+        "NIST"
+      ],
+      "title": "Guide to Industrial Control Systems (ICS) Security",
+      "publisher": "NIST Special Publication 800-82",
+      "id": "nis15"
+    },
+    "Oos10": {
+      "authors": [
+        "M. Oosdijk",
+        "et al."
+      ],
+      "href": "https://tnc2011.terena.org/getfile/696",
+      "title": "Provisioning scenarios in identity federations",
+      "publisher": "Surfnet Research Paper",
+      "date": "2010",
+      "id": "oos10"
+    },
+    "Owa17": {
+      "authors": [
+        "OWASP"
+      ],
+      "href": "https://www.owasp.org/index.php/Threat_Risk_Modeling",
+      "title": "Threat Risk Modeling",
+      "publisher": "OWASP",
+      "date": "Jan 2017",
+      "id": "owa17"
+    },
+    "Res03": {
+      "authors": [
+        "E. Rescorla",
+        "et al."
+      ],
+      "href": "https://tools.ietf.org/html/rfc3552",
+      "title": "Guidelines for Writing RFC Text on Security Considerations",
+      "publisher": "IETF RFC 3552 (IAB Guideline)",
+      "date": "2003",
+      "id": "res03"
+    },
+    "Sch14": {
+      "authors": [
+        "B. Schneier"
+      ],
+      "href": "https://www.wired.com/2014/01/theres-no-good-way-to-patch-the-internet-of-things-and-thats-a-huge-problem/",
+      "title": "The Internet of Things Is Wildly Insecure — And Often Unpatchable",
+      "publisher": "Wired",
+      "date": "Jan. 2014",
+      "id": "sch14"
+    },
+    "Sch99": {
+      "authors": [
+        "B. Scheier",
+        "A. Shostack"
+      ],
+      "href": "https://www.schneier.com/paper-smart-card-threats.pdf",
+      "title": "Breaking Up Is Hard To Do: Modeling Security Threats for Smart Cards",
+      "publisher": "USENIX Workshop on Smart Card Technology, USENIX Press",
+      "date": "1999",
+      "pages": "175-185",
+      "id": "sch99"
+    },
+    "She14": {
+      "authors": [
+        "Z. Shelby",
+        "et al."
+      ],
+      "href": "https://tools.ietf.org/rfc/rfc7252.txt",
+      "title": "The Constrained Application Protocol (CoAP)",
+      "publisher": "IETF RFC 7252",
+      "date": "June 2014",
+      "id": "she14"
+    },
+    "Vol00": {
+      "authors": [
+        "J. Vollbrecht",
+        "et al."
+      ],
+      "href": "https://tools.ietf.org/rfc/rfc2904.txt",
+      "title": "AAA Authorization Framework",
+      "publisher": "IETF RFC 2904",
+      "date": "Aug. 2000",
+      "id": "vol00"
+    },
+    "Yeg11": {
+      "authors": [
+        "S. Yegge"
+      ],
+      "href": "https://plus.google.com/+RipRowan/posts/eVeouesvaVX",
+      "title": "Stevey's Google Platforms Rant",
+      "publisher": "Blog",
+      "date": "Oct. 2011",
+      "id": "yeg11"
+    },
+    "ITUx1500": {
+      "authors": [
+        "ITU-T SG17"
+      ],
+      "href": "https://www.itu.int/rec/T-REC-X.1500",
+      "title": "ITU-T Rec. X.1500 Overview of cybersecurity information exchange",
+      "publisher": "International Telecommunication Union",
+      "date": "Apr 2011",
+      "id": "itux1500"
+    },
+    "ITUx1520": {
+      "authors": [
+        "ITU-T SG17"
+      ],
+      "href": "https://www.itu.int/rec/T-REC-X.1520",
+      "title": "ITU-T Rec. X.1520 Common vulnerabilities and exposures",
+      "publisher": "International Telecommunication Union",
+      "date": "Jan 2014",
+      "id": "itux1520"
+    },
+    "ITUx1524": {
+      "authors": [
+        "ITU-T SG17"
+      ],
+      "href": "https://www.itu.int/rec/T-REC-X.1524",
+      "title": "ITU-T Rec. X.1524 Common weakness enumeration",
+      "publisher": "International Telecommunication Union",
+      "date": "March 2012",
+      "id": "itux1524"
+    },
+    "Owa18": {
+      "authors": [
+        "OWASP"
+      ],
+      "href": "https://www.owasp.org/index.php/Web_Service_Security_Testing_Cheat_Sheet",
+      "title": "Web Service Security Testing",
+      "publisher": "OWASP",
+      "date": "Aug 2018",
+      "id": "owa18"
+    },
+    "FuzzCoAP": {
+      "href": "https://github.com/bsmelo/fuzzcoap",
+      "title": "FuzzCoAP - Fuzzing for Robustness and Security Testing of CoAP Servers",
+      "id": "fuzzcoap"
+    },
+    "Wfuzz": {
+      "href": "http://www.edge-security.com/wfuzz.php",
+      "title": "Wfuzz. The web application Bruteforcer",
+      "id": "wfuzz"
+    },
+    "Snyk": {
+      "href": "https://snyk.io/",
+      "title": "A developer-first solution that automates finding and fixing vulnerabilities in your dependencies",
+      "id": "snyk"
+    },
+    "OWASP-Dependency-Check": {
+      "href": "https://www.owasp.org/index.php/OWASP_Dependency_Check",
+      "title": "OWASP Dependency Check",
+      "id": "owasp-dependency-check"
+    },
+    "w3af": {
+      "href": "http://w3af.org/",
+      "title": "Web Application Attack and Audit Framework",
+      "id": "w3af"
+    },
+    "Burp": {
+      "href": "https://portswigger.net/burp",
+      "title": "Burp Suite Web vulnerability scanner",
+      "id": "burp"
+    },
+    "Protecode": {
+      "href": "https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html",
+      "title": "Black Duck Software Composition Analysis",
+      "id": "protecode"
+    },
+    "PeachPit-COAP": {
+      "href": "https://www.peach.tech/wp-content/uploads/CoAP_DataSheet.pdf",
+      "title": "CoAP Peach Pit User Guide",
+      "id": "peachpit-coap"
+    },
+    "wapiti": {
+      "href": "http://wapiti.sourceforge.net/",
+      "title": "Wapiti - The web-application vulnerability scanner",
+      "id": "wapiti"
+    },
+    "Coverity": {
+      "href": "https://community.synopsys.com/s/article/Coverity-Tutorial-Introduction-to-Coverity",
+      "title": "Coverity Tutorial: Introduction to Coverity",
+      "id": "coverity"
+    },
+    "Klocwork": {
+      "href": "https://www.roguewave.com/products-services/klocwork",
+      "title": "Klocwork. Faster delivery of secure, reliable, and conformant code",
+      "id": "klocwork"
+    },
+    "Checkmarx": {
+      "href": "https://www.checkmarx.com/",
+      "title": "Checkmarx project page",
+      "id": "checkmarx"
+    },
+    "CoverityOnline": {
+      "href": "https://scan.coverity.com",
+      "title": "Coverity online scanning service",
+      "id": "coverityonline"
+    },
+    "Wireshark": {
+      "href": "https://www.wireshark.org/",
+      "title": "Wireshark project page",
+      "id": "wireshark"
+    },
+    "tcpdump": {
+      "href": "https://www.tcpdump.org/",
+      "title": "tcpdump and libpcap project page",
+      "id": "tcpdump"
+    },
+    "exploit-db": {
+      "href": "https://www.exploit-db.com/",
+      "title": "Exploit database project page",
+      "id": "exploit-db"
+    },
+    "WATOBO": {
+      "href": "http://watobo.sourceforge.net/index.html",
+      "title": "WATOBO. The Web Application Toolbox",
+      "id": "watobo"
+    },
+    "Nikto": {
+      "href": "https://cirt.net/Nikto2",
+      "title": "Nikto web server scanner",
+      "id": "nikto"
+    },
+    "Pri19": {
+      "authors": [
+        "M. Pritikin, M. Richardson, T. Eckert,M. Behringer, K. Watsen"
+      ],
+      "href": "https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-26",
+      "title": "Bootstrapping Remote Secure Key Infrastructures (BRSKI)",
+      "publisher": "IETF",
+      "date": "Aug. 2019",
+      "id": "pri19"
+    },
+    "SDO": {
+      "href": "https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/intel-secure-device-onboard-product-brief.pdf",
+      "title": "Intel® Secure Device Onboard",
+      "publisher": "Intel",
+      "date": "2017",
+      "id": "sdo"
+    }
+  },
+  "publishISODate": "2023-08-08T00:00:00.000Z",
+  "generatedSubtitle": "Editor's Draft 08 August 2023"
+}</script><link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED"></head>
+  <body class="h-entry informative toc-inline"><div class="head">
+    <a class="logo" href="https://www.w3.org/"><img alt="W3C" width="72" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"></a> <h1 id="title" class="title">Web of Things (WoT) Security and Privacy Guidelines</h1>
+    
+    <h2>
+      W3C Editor's Draft
+      <time class="dt-published" datetime="2023-08-08">08 August 2023</time>
+    </h2>
+    <dl>
+      <dt>This version:</dt><dd>
+              <a class="u-url" href="https://w3c.github.io/wot-security/">https://w3c.github.io/wot-security/</a>
+            </dd><dt>Latest published version:</dt><dd>
+              <a href="https://www.w3.org/TR/wot-security/">https://www.w3.org/TR/wot-security/</a>
+            </dd>
+      <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/wot-security/">https://w3c.github.io/wot-security/</a></dd>
+      
+      
+      
+      
+      
+      <dt>Editors:</dt>
+      <dd class="p-author h-card vcard" data-editor-id="99327"><span class="p-name fn">Elena Reshetova</span>
+            (<a class="p-org org h-org h-card" href="https://www.intel.com/">Intel Corp.</a>)
+          </dd><dd class="p-author h-card vcard" data-editor-id="93137"><span class="p-name fn">Michael McCool</span>
+            (<a class="p-org org h-org h-card" href="https://www.intel.com/">Intel Corp.</a>)
+          </dd>
+      
+      
+      <dt>Contributors:</dt><dd>
+    <a href="https://github.com/w3c/wot-security/graphs/contributors">In the GitHub repository</a>
+  </dd><dt>Repository:</dt><dd>
+    <a href="https://github.com/w3c/wot-security/">We are on GitHub</a>
+  </dd><dd>
+    <a href="https://github.com/w3c/wot-security/issues">File a bug</a>
+  </dd><dd>
+    <a href="https://github.com/w3c/wot-security/pulls">Contribute</a>
+  </dd>
+    </dl>
+    
+    
+    
+    <p class="copyright">
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
+    ©
+    2017-2023
+    
+    <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+    <a href="https://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="https://www.keio.ac.jp/">Keio</a>,
+    <a href="https://ev.buaa.edu.cn/">Beihang</a>). 
+    W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules
+    apply.
+  </p>
+    <hr title="Separator for header">
+  </div>
+    <section id="abstract" class="introductory"><h2>Abstract</h2>
+     <p>
+     This document provides non-normative guidance on Web of Things (WoT) security and privacy.
+     The Web of Things is descriptive, not prescriptive,
+     and so is generally designed to support the security models and mechanisms of the systems it describes,
+     not introduce new ones.
+     However, a WoT System also has its own unique assets, such as a Scripting API and Thing Descriptions, that
+     need to be protected and also have security and privacy implications.
+     </p><p>
+     We define the general security requirements for a Web of Things (WoT) System using a threat model.
+     The WoT threat model defines the main security stakeholders, security-relevant assets,
+     possible attackers, attack surfaces,
+     and finally threats for a WoT System.
+     Using this generic WoT threat model for guidance,
+     it should be possible to select a specific set of security objectives for a concrete WoT System implementation.
+     We provide several examples using common scenarios based on home, enterprise, and industrial use cases.
+     We also provide more general suggestions for the design and deployment of a secure WoT System.
+     All recommendations are linked to the corresponding WoT threats in the generic woT threat model in order to
+     facilitate understanding of why they are needed.
+     </p><p>
+     It is not the intention of this document to limit the set of security mechanisms that can be used to 
+     secure a WoT System.
+     In particular, while we provide examples and recommendations based on the best available practices in the industry,
+     this document contains informative statements only.
+     Specific normative security aspects of the WoT specification are defined in the corresponding normative WoT documents
+     for each WoT building block.
+     </p>
+     <div class="note" id="issue-container-generatedID"><div role="heading" class="ednote-title marker" id="h-ednote" aria-level="3"><span>Editor's note</span></div><p class="">
+        This content should be consistent with the summaries in the 
+        Security sections of other WoT documents, in particular the
+	[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>] and [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">WoT-Thing-Description</a></cite>] 
+        documents.
+     </p></div>
+    </section>
+
+    <section id="sotd" class="introductory"><h2>Status of This Document</h2><p><em>This section describes the status of this
+      document at the time of its publication. Other documents may supersede
+      this document. A list of current <abbr title="World Wide Web Consortium">W3C</abbr> publications and the latest revision
+      of this technical report can be found in the
+      <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> technical reports index</a> at
+      https://www.w3.org/TR/.</em></p>
+      <div class="note" id="issue-container-generatedID-0"><div role="heading" class="ednote-title marker" id="h-ednote-0" aria-level="3"><span>Editor's note</span><span class="issue-label">: The W3C WoT WG is asking for feedback</span></div><p class="">
+        Please contribute to this draft using the <a href="https://github.com/w3c/wot-security/issues">GitHub Issue</a> feature of the <a href="https://github.com/w3c/wot-security/">WoT Security and Privacy Considerations</a> repository.
+      </p></div>
+    <p>
+    This document was published by the <a href="https://www.w3.org/WoT/WG/">Web of Things Working Group</a> as an
+    Editor's Draft.
+    
+  </p><p>
+    
+    Comments regarding this document are welcome.
+          Please send them to
+          <a href="mailto:public-wot-wg@w3.org">public-wot-wg@w3.org</a>
+          (<a href="https://lists.w3.org/Archives/Public/public-wot-wg/">archives</a>).
+        
+  </p><p>
+    Publication as an Editor's Draft does not imply endorsement by the <abbr title="World Wide Web Consortium">W3C</abbr>
+    Membership. This is a draft document and may be updated, replaced or
+    obsoleted by other documents at any time. It is inappropriate to cite this
+    document as other than work in progress.
+  </p><p>
+    
+        This document was produced by a group
+        operating under the
+        <a href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+       The group does not expect this document to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
+    
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+                <a rel="disclosure" href="">public list of any patent disclosures</a>
+          made in connection with the deliverables of
+          the group; that page also includes
+          instructions for disclosing a patent. An individual who has actual
+          knowledge of a patent which the individual believes contains
+          <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a>
+          must disclose the information in accordance with
+          <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+        
+    
+  </p><p>
+                  This document is governed by the
+                  <a id="w3c_process_revision" href="https://www.w3.org/2019/Process-20190301/">1 March 2019 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+                </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#related-w3c-documents"><bdi class="secno">1.1 </bdi>Related <abbr title="World Wide Web Consortium">W3C</abbr> Documents</a></li></ol></li><li class="tocline"><a class="tocxref" href="#e-wot-device-lifecycle"><bdi class="secno">2. </bdi>Lifecycle of a WoT Device</a></li><li class="tocline"><a class="tocxref" href="#requirements"><bdi class="secno">3. </bdi>Requirements</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#general"><bdi class="secno">3.1 </bdi>General</a></li><li class="tocline"><a class="tocxref" href="#wot-threat-model"><bdi class="secno">3.2 </bdi>Threat Model</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#wot-threat-model-stakeholders"><bdi class="secno">3.2.1 </bdi>WoT Primary Stakeholders</a></li><li class="tocline"><a class="tocxref" href="#wot-threat-model-assets"><bdi class="secno">3.2.2 </bdi>Assets</a></li><li class="tocline"><a class="tocxref" href="#wot-threat-adversaries"><bdi class="secno">3.2.3 </bdi>Adversaries</a></li><li class="tocline"><a class="tocxref" href="#e-wot-threat-model-attack-surfaces"><bdi class="secno">3.2.4 </bdi>Attack Surfaces</a></li><li class="tocline"><a class="tocxref" href="#wot-threat-model-threats"><bdi class="secno">3.2.5 </bdi>Threats</a></li></ol></li><li class="tocline"><a class="tocxref" href="#wot-security-scenarios"><bdi class="secno">3.3 </bdi>Security Scenarios</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#scenario-1-home-environment"><bdi class="secno">3.3.1 </bdi>Scenario 1 - Home Environment</a></li><li class="tocline"><a class="tocxref" href="#scenario-2-business-corporate-environment"><bdi class="secno">3.3.2 </bdi>Scenario 2 - Business/Corporate Environment</a></li><li class="tocline"><a class="tocxref" href="#scenario-3-industrial-critical-infrastructure-environment"><bdi class="secno">3.3.3 </bdi>Scenario 3 - Industrial/Critical Infrastructure Environment</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#wot-privacy"><bdi class="secno">4. </bdi>Privacy Considerations</a></li><li class="tocline"><a class="tocxref" href="#security-provisioning-onboarding-and-maintenance"><bdi class="secno">5. </bdi>Security Provisioning(Onboarding) and Maintenance</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#goals-and-requirements"><bdi class="secno">5.1 </bdi>Goals and requirements</a></li><li class="tocline"><a class="tocxref" href="#existing-approaches"><bdi class="secno">5.2 </bdi>Existing approaches</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#bootstrapping-remote-secure-key-infrastructures-brski"><bdi class="secno">5.2.1 </bdi>Bootstrapping Remote Secure Key Infrastructures (BRSKI)</a></li><li class="tocline"><a class="tocxref" href="#intel-secure-device-onboard-sdo"><bdi class="secno">5.2.2 </bdi>Intel Secure Device Onboard (SDO)</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#references-to-existing-security-best-practices"><bdi class="secno">6. </bdi>References to Existing Security Best Practices</a></li><li class="tocline"><a class="tocxref" href="#security-mitigations"><bdi class="secno">7. </bdi>Best Security Practices and Mitigations for WoT Systems</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#secure-practices-for-designing-a-thing-description"><bdi class="secno">7.1 </bdi>Secure Practices for designing a Thing Description</a></li><li class="tocline"><a class="tocxref" href="#sec-pract-system-user-data"><bdi class="secno">7.2 </bdi>Secure Practices for protecting System User Data</a></li><li class="tocline"><a class="tocxref" href="#sec-pract-wot-interfaces"><bdi class="secno">7.3 </bdi>Secure Practices for designing WoT Interfaces</a></li><li class="tocline"><a class="tocxref" href="#sec-pract-end-to-end-security"><bdi class="secno">7.4 </bdi>Secure Practices for End-to-End security</a></li></ol></li><li class="tocline"><a class="tocxref" href="#examples-of-wot-security-configurations"><bdi class="secno">8. </bdi>Examples of WoT Security Configurations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#wot-client-server-basic"><bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a></li><li class="tocline"><a class="tocxref" href="#interaction-between-wot-thing-and-wot-consumer-via-an-intermediary-wot-servient"><bdi class="secno">8.2 </bdi>Interaction between WoT Thing and WoT Consumer via an Intermediary WoT Servient</a></li><li class="tocline"><a class="tocxref" href="#wot-client-server-double-proxy"><bdi class="secno">8.3 </bdi>Basic Interaction between WoT Thing and WoT Consumer via a Split Proxy</a></li><li class="tocline"><a class="tocxref" href="#wot-client-server-tunnel"><bdi class="secno">8.4 </bdi>Basic Interaction between WoT Thing and WoT Consumer via a Tunnel</a></li><li class="tocline"><a class="tocxref" href="#wot-servient-single-tenant"><bdi class="secno">8.5 </bdi>WoT Servient Single-Tenant</a></li><li class="tocline"><a class="tocxref" href="#wot-servient-multi-tenant"><bdi class="secno">8.6 </bdi>WoT Servient Multi-Tenant</a></li></ol></li><li class="tocline"><a class="tocxref" href="#e-security-validation"><bdi class="secno">9. </bdi>Security Validation</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#testing-goals"><bdi class="secno">9.1 </bdi>Testing Goals</a></li><li class="tocline"><a class="tocxref" href="#best-practices"><bdi class="secno">9.2 </bdi>Best Practices</a></li><li class="tocline"><a class="tocxref" href="#functional-security-testing"><bdi class="secno">9.3 </bdi>Functional Security Testing</a></li><li class="tocline"><a class="tocxref" href="#adversarial-security-testing"><bdi class="secno">9.4 </bdi>Adversarial Security Testing</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#static-weakness-discovery"><bdi class="secno">9.4.1 </bdi>Static Weakness Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#static-code-analysis"><bdi class="secno">9.4.1.1 </bdi>Static Code Analysis</a></li><li class="tocline"><a class="tocxref" href="#known-vulnerability-checking"><bdi class="secno">9.4.1.2 </bdi>Known vulnerability checking</a></li></ol></li><li class="tocline"><a class="tocxref" href="#runtime-weakness-discovery"><bdi class="secno">9.4.2 </bdi>Runtime (Dynamic) Weakness Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#fuzz-testing"><bdi class="secno">9.4.2.1 </bdi>Fuzz Testing</a></li><li class="tocline"><a class="tocxref" href="#protocol-analysis"><bdi class="secno">9.4.2.2 </bdi>Protocol Analysis</a></li><li class="tocline"><a class="tocxref" href="#vulnerability-scanners"><bdi class="secno">9.4.2.3 </bdi>Vulnerability Scanners</a></li></ol></li><li class="tocline"><a class="tocxref" href="#exploitation"><bdi class="secno">9.4.3 </bdi>Exploitation</a></li></ol></li><li class="tocline"><a class="tocxref" href="#security-testing-plan-framework"><bdi class="secno">9.5 </bdi>Security Testing Plan Framework</a></li><li class="tocline"><a class="tocxref" href="#suggested-testing-frequency"><bdi class="secno">9.6 </bdi>Suggested Testing Frequency</a></li><li class="tocline"><a class="tocxref" href="#summary"><bdi class="secno">9.7 </bdi>Summary</a></li></ol></li><li class="tocline"><a class="tocxref" href="#e-terminology"><bdi class="secno">10. </bdi>Terminology</a></li><li class="tocline"><a class="tocxref" href="#e-changes"><bdi class="secno">A. </bdi>Change Log</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#e-changes-from-second-release"><bdi class="secno">A.1 </bdi>Changes from Second Release</a></li><li class="tocline"><a class="tocxref" href="#e-changes-from-first-release"><bdi class="secno">A.2 </bdi>Changes from First Release</a></li></ol></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">B. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">B.1 </bdi>
+        Informative references
+      </a></li></ol></li></ol></nav>
+
+    <section id="introduction">
+      <h2 id="x1-introduction"><bdi class="secno">1. </bdi>Introduction<a class="self-link" aria-label="§" href="#introduction"></a></h2>
+      <p>Security of a WoT System can refer to the security of the Thing Description (TD) itself or 
+      the security of the Thing the Thing Description describes.
+    </p><section id="related-w3c-documents">
+      <h3 id="x1-1-related-w3c-documents"><bdi class="secno">1.1 </bdi>Related <abbr title="World Wide Web Consortium">W3C</abbr> Documents<a class="self-link" aria-label="§" href="#related-w3c-documents"></a></h3>
+      <p>
+        For a general discussion of best practices for developing secure WoT Systems, 
+        as well as a set of suggested combinations of authentication mechanisms
+        and secured protocols,
+        see the <a href="https://github.com/w3c/wot-security-best-practices/">WoT 
+        Security Best Practices</a> document.
+      </p>
+      <p>For details on the Web of Things architecture, please refer to the following:
+      </p><ul>
+        <li>the <a href="https://www.w3.org/WoT/IG/">Interest Group</a> web site</li>
+        <li>the <a href="https://www.w3.org/WoT/WG/">Working Group</a> web site</li>
+        <li>the [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>] document,</li> 
+        <li>the [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">WoT-Thing-Description</a></cite>] document,</li>
+        <li>the [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WoT-Binding-Templates</a></cite>] document, and</li>
+        <li>the [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-scripting-api" title="Web of Things (WoT) Scripting API">WoT-Scripting-API</a></cite>] document.</li>
+      </ul>
+      <p></p>
+</section>
+    </section>
+
+    <section id="wot-device-lifecycle">
+      <h2 id="e-wot-device-lifecycle"><bdi class="secno">2. </bdi>Lifecycle of a WoT Device<a class="self-link" aria-label="§" href="#e-wot-device-lifecycle"></a></h2>
+
+      <figure id="wot-lifecycle">
+           <img src="images/WoT_lifecycle_diagram.png" width="100%" title="WoT Device Lifecycle">
+           <figcaption>Figure <bdi class="figno">1</bdi> <span class="fig-title">WoT Device Lifecycle</span></figcaption>
+       </figure>
+
+      <p>The lifecycle of a WoT Device is similar to the lifecycles of other IoT devices and services.
+      It may in fact be identical if a WoT Thing Description is being used simply to describe an existing device
+      implemented using another standard.
+      However, 
+      for discussion purposes we will use the generic lifecycle shown in <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a> 
+      which includes the following states:
+      </p><ul>
+        <li><strong>Manufactured:</strong> The WoT Device has been manufactured by an OEM.
+		It might have a WoT runtime present that enables single or multi-tenant users 
+                or it might only have network interfaces exposed present that are compatible with a WoT description.
+		From the Manufactured state, based on the deployment scenario, the device can transition to either of two states: 
+		the Installation/Commissioning state or the Security Provisioning state.</li>
+        <li><strong>Installation/Commissioning:</strong> A WoT Device has been installed into its intended deployment environment
+		by a system provider or system integrator and any necessary SW configuration has been performed. 
+		In practice this state may be combined with or reordered with the Security Provisioning state.</li>
+        <li><strong>Security Provisioning:</strong> A WoT Device is provisioned with the security metadata and credentials needed 
+		during its Operational state. 
+		The exact set of necessary credentials will vary based on the WoT Device's deployment model and choice of security mechanisms. 
+		The document <cite>The State-of-the-Art and Challenges for the Internet of Things Security</cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-garcia17" title="State-of-the-Art and Challenges for the Internet of Things Security">Garcia17</a></cite>] 
+		refers to this stage as "Bootstrapping".</li>
+        <li><strong>Operational:</strong> The default operational state of WoT Devices. 
+		Devices in this state are fully ready to communicate over WoT interfaces and satisfy their deployment's operational roles. 
+		From the Operational state a device can return to the Manufactured state 
+                if it is fully decommissioned and security de-provisioned 
+		(link E in <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a>). 
+		It is also possible to perform only a partial reset of a device,
+		if it only requires re-installation and recommissioning without security re-provisioning 
+		(link D in <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a>).
+		It is also possible that only security re-provisioning is needed 
+                without re-installation and re-commissioning (link C in <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a>).</li>
+        <li><strong>Maintenance and Security Update:</strong> 
+                A state that is entered when the device's software or configuration needs to be updated.
+	        This is an optional state that can be activated remotely or locally (link A in <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a>) 
+		on a WoT Device depending on the deployment model and overall setup. 
+		This state can be required to maintain security,
+                for example to patch SW vulnerabilities or perform security-related configuration updates, 
+		such as key revocation or certificate refresh. 
+		After maintenance or updates are done, 
+		the device normally returns to the Operational state (link B in <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a>). </li>
+      </ul>
+      The scope of this document only covers the Security Provisioning, Operational and Maintenance and Security
+      Update States of a WoT Device.
+      <p></p>
+    </section>
+
+  <section id="requirements">
+    <h2 id="x3-requirements"><bdi class="secno">3. </bdi>Requirements<a class="self-link" aria-label="§" href="#requirements"></a></h2>
+	
+        <section id="general">
+        <h3 id="x3-1-general"><bdi class="secno">3.1 </bdi>General<a class="self-link" aria-label="§" href="#general"></a></h3>
+            <p>
+            In general using the WoT approach should "do no harm": the security of any protocols should be maintained.
+            The Web of Things does not introduce new security mechanisms, 
+            but should preserve the functionality and security of existing mechanisms.
+            We also have the following requirements:
+            </p><ul>
+                <li><strong>Exposing:</strong>
+                When exposing a TD, especially via the Scripting API,
+                it should be possible to use best practices for security,
+                including maintaining the integrity of the TD and delivering it only to authorized recipients.</li>
+                <li><strong>Consuming:</strong>
+		A consumed TD should accurately reflect the actual security status of the device it describes.</li>
+                <li><strong>Protocols:</strong>
+                The WoT can potentially apply to many protocols but to limit scope in this 
+                discussion we will focus on the needs of HTTP(S), CoAP(S), and MQTT(S).</li>
+            </ul>
+            <p></p>
+        </section>
+
+        <section id="wot-threat-model">
+        <h3 id="x3-2-threat-model"><bdi class="secno">3.2 </bdi>Threat Model<a class="self-link" aria-label="§" href="#wot-threat-model"></a></h3>
+            <p> 
+              Due to the large diversity of devices, use cases, 
+	      deployment scenarios and requirements for WoT Things,
+              it is impossible to define a single WoT threat model that would fit every case.
+              Instead we describe here an overall WoT threat model framework that can be adjusted
+              by OEMs or other WoT System users or providers based on their concrete security requirements.
+	      This framework gives a set of possible threats that implementers should
+	      consider, but which may or may not apply to their WoT System.
+            </p>
+            <p>
+            When selecting suitable mitigations to the WoT threats described, it is important to consider various
+            criteria that might increase the risk level for a particular WoT architecture, such as handing
+            privacy-sensitive data, physical safety of individuals or the surrounding environment, high
+            availability requirements, and so forth.
+            In addition threat mitigations will always be limited by the capabilities of underlying 
+            devices, their list of supported security protocols, processes isolation capabilities, etc. 
+            </p>
+
+ <section id="wot-threat-model-stakeholders">
+    <h4 id="x3-2-1-wot-primary-stakeholders"><bdi class="secno">3.2.1 </bdi>WoT Primary Stakeholders<a class="self-link" aria-label="§" href="#wot-threat-model-stakeholders"></a></h4>
+    <p>This section lists the primary WoT stakeholders.</p>
+		<table>
+		    <tbody><tr>
+			<th>Stakeholder</th>
+			<th>Description</th>
+			<th>Security goals</th>
+			<th>Edge cases</th>
+		    </tr><tr>
+			<th><dfn data-lt="device manufacturer|device manufacturers|manufacturer|oem|Device Manufacturer" data-dfn-type="dfn" id="dfn-device-manufacturer">
+                            Device Manufacturer</dfn> (OEM)</th>
+			<td>
+      Producer of the HW device. 
+      Implements the WoT runtime on the device, 
+      defines Things that the device provides, and generates TDs for these Things.</td>
+      <td>
+      Don't want the devices they make to be used in any form of attack
+      (due to loss of reputation and possible legal consequences in some countries).
+      Want to satisfy the security requirements of <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System users</a>
+      and <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System providers</a> to maximize HW sales.</td>
+			<td></td>
+		  </tr><tr>
+			<th><dfn data-lt="system provider|system providers|System Provider" data-dfn-type="dfn" id="dfn-system-provider">
+      System Provider</dfn><br> or
+      <dfn data-lt="system integrator|system integrators|System Integrator" data-dfn-type="dfn" id="dfn-system-integrator">
+      System Integrator</dfn><br> or
+      <dfn data-lt="system installer|system installers|System Installer" data-dfn-type="dfn" id="dfn-system-installer">
+      System Installer</dfn></th>
+			<td>
+      Uses devices from <a href="#dfn-device-manufacturer" class="internalDFN" data-link-type="dfn">OEM</a>s to build various WoT end solutions
+      specific to particular WoT use case(s).
+      An <a href="#dfn-device-manufacturer" class="internalDFN" data-link-type="dfn">OEM</a> might simultaneously be a System Provider,
+      although System Providers might also
+      define new TDs or modify TDs provided by other entities (<a href="#dfn-device-manufacturer" class="internalDFN" data-link-type="dfn">OEM</a>s).
+      System Providers
+      might use the WoT scripting API and runtime to implement their solution
+      or might do a full reflash of the device to install their own software stack.
+      A System Provider's scripts and their configuration data might require
+      confidentiality and/or integrity.
+      A System Integrator/Installer is similar to a System Provider but tends to
+      reuse rather than create new technology.
+      </td>
+      <td>Don't want their WoT System to be a target of any attacks
+      (loss of reputation, possible legal consequences in some countries).
+      Want to satisfy security requirements of System users for better sales.
+      Don't want security to interfere with usability for better sales
+      (usability vs. security).
+      
+      Want their WoT System to be robust and be resistant to DoS attacks.
+      Want to hide their proprietary scripts and other relevant data from other parties.
+      </td>
+      <td>
+      There might be several independent system providers (tenants) on a single HW device.
+      In that case isolation between them is required while (perhaps) sharing 
+      user preferences and identification.
+      </td>
+      </tr><tr>
+      <th><dfn data-lt="system user|system users|System User" data-dfn-type="dfn" id="dfn-system-user">System User</dfn></th>
+      <td>
+      These might be physical users (e.g. John and his family in their smart home)
+      or abstract users (e.g. the company running a factory). 
+      The primary characteristic of this stakeholder is the need to use 
+      the WoT System to obtain some functionality. 
+      System Users entrust WoT Systems with their data 
+      (video streams from home cameras or factory plans) or physical capabilities 
+      in the surrounding environment (put lights on in a room or start a machine on the factory line).
+      They might differ in their access to the WoT System
+      and transferred data (for example, they might only be able to configure
+      certain parts of the network or only use it as it is).
+      </td>
+      
+      <td>
+      Don't want their data to be exposed to any other System User,
+      <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a> or <a href="#dfn-device-manufacturer" class="internalDFN" data-link-type="dfn">OEM</a> unless intended (Data Confidentiality).
+      Don't want their data to be modified unless intended (Data Integrity).</td>
+      <td>Access to user data might be configurable based not only on "who"
+      is the entity accessing the data (access control subject), 
+      but also his/her/its role,
+      type of access, or time and context.</td>
+      </tr><tr>
+      <th><dfn data-lt="system owner|system owners|System Owner" data-dfn-type="dfn" id="dfn-system-owner">System Owner</dfn></th>
+      <td>
+      An entity that provisions a Thing with the security root of trust
+      and sets up the initial policies on who can provision/update/remove scripts
+      to/from the WoT runtimes, if such model is supported.
+      Any of the above stakeholders can be the System Owner depending on the
+      concrete setup.
+      A WoT System might have a number of independent System Owners,
+      each with their own set of provisioned certificates and/or credentials.
+      Underlying IoT protocol suites may also have their own notion of ownership.
+      </td>
+      <td>
+      Want to have a full control over their own provisioned security credentials,
+      including their integrity and confidentiality.
+      </td>
+      <td></td>
+      </tr><tr>
+      <th><dfn data-lt="system maintainer|system maintainers|System Maintainer" data-dfn-type="dfn" id="dfn-system-maintainer">System Maintainer</dfn></th>
+      <td>
+      This is an optional stakeholder.
+      It administers a WoT System on behalf of a <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>
+      or <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System User</a>
+      </td>
+      <td>
+      Needs to have enough access to the WoT System to perform its duties.
+      Should have minimal (ideally none) access to the data of other stakeholders.  
+      </td>
+      <td></td>
+      </tr>
+      </tbody></table>
+    </section>
+
+       
+
+    <section id="wot-threat-model-assets">
+    <h4 id="x3-2-2-assets"><bdi class="secno">3.2.2 </bdi>Assets<a class="self-link" aria-label="§" href="#wot-threat-model-assets"></a></h4>
+         <p>This section lists all WoT Assets that are important from a security point of view.</p>
+         <table>
+         <tbody><tr>
+            <th>Asset</th>
+            <th>Description</th>
+            <th>Who should have access<br>(Trust Model)</th>
+            <th>Attack Points</th>
+         </tr><tr>
+            <th><dfn data-lt="thing descriptions|td|tds|Thing Description" data-dfn-type="dfn" id="dfn-thing-descriptions">
+                 Thing Description</dfn> (TD)</th>
+            <td>Access Control policies for TDs and the resources it describes are part of TDs. 
+            They are managed using a discretionary access control model 
+            (the owner of a TD sets the AC policy).
+            Some contents of TDs might be privacy sensitive and therefore should not be shared without a specific need.
+            The integrity of TDs is crucial for the correct operation of a WoT System.
+            </td>
+                 <td>TD owner: full access<br> 
+                     Others: read only for minimal required part.</td>
+                 <td>Storage on thing itself, cloud storage, in-transfer (network) including TD updates.</td>
+         </tr><tr>
+            <th><dfn data-lt="system user data|System User Data" data-dfn-type="dfn" id="dfn-system-user-data">System User Data</dfn></th>
+            <td>This includes all data that is produced or processed by the elements of a WoT System,
+               i.e. sensor readings and their states, user configurations and preferences, actuator commands,
+               video/audio streams, etc.  Can be highly privacy sensitive and confidential.</td>
+            <td>Different <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System Users</a> might have different levels of
+            access to this data based on the use case. In some cases (like user preferences or settings)
+            the partial access to this asset is also needed by a <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>. 
+            Non-authorized access must be minimized since access even to a small amount of information
+            (for example the last timestamp when a door lock API was used) might have severe
+            privacy concerns (this example would allow an attacker to detect when the owner is away
+            from his house).
+            Security mechanisms should be flexible to configure and might also need to include RBAC.<br>
+            Others: should have no access unless specifically allowed</td>
+            <td>Storage on the device itself, remote solution provider storage (Cloud or other),
+            in-transfer (network)</td>
+          </tr><tr>
+            <th><dfn data-lt="system provider scripts|system provider script|System Provider Data" data-dfn-type="dfn" id="dfn-system-provider-scripts">
+                     System Provider Data</dfn>
+            </th><td>This includes both WoT scripts and any WoT configuration data produced and owned by a
+            <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>. It also includes Exposed Things, i.e.
+            run-time representations of scripts running inside a WoT Runtime.
+            <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System providers</a> might have Intellectual Property (IP) in their scripts,
+            making them highly confidential. 
+            Protocol Bindings might be part of System Provider Data, 
+            if a WoT Device has a single System Provider that 
+            installs and configures WoT Runtime and Protocol Bindings. 
+            However, these can be also provided and confgured by the OEM, 
+            and the same Protocol Bindings could be used by
+            multiple System Providers on the same device. </td>
+            <td><a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>: full access<br>
+            Others: no access</td>
+            <td>Storage on the device itself, runtime memory representation,
+            in-transfer only for initial provisioning and script updates
+            </td>
+          </tr><tr>
+            <th><dfn data-lt="thing resource|WoT Thing Resources" data-dfn-type="dfn" id="dfn-thing-resource">
+                     WoT Thing Resources</dfn><br> and
+                     <dfn data-lt="wot infrastructure resource|WoT Infrastructure Resources" data-dfn-type="dfn" id="dfn-wot-infrastructure-resource">
+                     WoT Infrastructure Resources</dfn></th>
+            <td>Resources should only be used for legitimate purposes and be available when required.</td>
+            <td><a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System User</a>, <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a></td>
+            
+            <td>WoT Interface</td>
+          </tr><tr>
+            <th><dfn data-dfn-type="dfn" id="dfn-wot-controlled-environment">WoT Controlled Environment</dfn></th>
+            <td>WoT Devices that have actuator capabilities are able to affect the physical environment
+            around them.
+            Such capability must only be used by authorized entities and for legitimate purposes.
+            An actuator capability also implies a possible safety risk.</td>
+            <td><a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System User</a>, <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a> and whoever is explicitly authorized by them to control the environment. </td>
+            <td>WoT Interface</td>
+          </tr><tr>
+            <th><dfn data-dfn-type="dfn" id="dfn-wot-behavior-metrics">WoT Behavior Metrics</dfn></th>
+            <td>Indirectly transmitted information (metadata) that represents measurements of 
+            a WoT System's behavior from which other information can be inferred, such as user presence. 
+            For example, the amount of communication between different things,
+            the APIs used, distribution of communication over time, etc.</td>
+            <td>It should not be possible to collect/identify indirectly transferable information</td>
+            <td>In-transfer data and usage of WoT Interface</td>
+          </tr><tr>
+            <th><dfn data-dfn-type="dfn" id="dfn-wot-basic-security-metadata">WoT Basic Security Metadata</dfn></th>
+            <td>All required security metadata (keys, certificates etc.) that might be provisioned 
+            to the WoT Device in order to be able to perform various security-related operations, 
+            such as authenticating another device or WoT Consumer in the WoT System, 
+            authenticating remote authorization service in case the access control to WoT interfaces is done using tokens, etc.</td>
+            <td> Manager Thing (if present in WoT Runtime) - an entity that can implement script lifecycle management operations, WoT Runtime </td>
+            <td> On device storage, in-transfer including provisioning and updates of security metadata.
+            </td>
+          </tr>
+          </tbody></table>
+
+          <p>The term <dfn data-dfn-type="dfn" id="dfn-thing-data">Thing Data</dfn> can be used to refer to either
+             <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> or <a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Data</a>.</p>
+
+          <p>If a WoT System supports dynamic installation of scripts
+             inside WoT runtime, the following assets are added:</p>
+
+          <table>
+              <tbody><tr>
+                  <th>Asset</th>
+                  <th>Description</th>
+                  <th>Who should have access?<br>(Trust Model)</th>
+                  <th>Attack Points</th>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-script-security-metadata">WoT Script Security Metadata</dfn></th>
+                  <td>Defines who can provision, install, update, and remove scripts and other
+                      <a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Data</a> inside a WoT runtime.</td>
+                  <td><a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>, <a href="#dfn-system-maintainer" class="internalDFN" data-link-type="dfn">System Maintainer</a></td>
+                  <td>WoT Script Management Interface</td>
+              </tr>
+          </tbody></table>
+
+          <p>If a WoT System allows co-existence of different independent <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Providers</a> (tenants)
+             on a single physical device, the following assets are added:</p>
+
+          <table>
+              <tbody><tr>
+                  <th>Asset</th>
+                  <th>Description</th>
+                  <th>Who should have access?<br>(Trust Model)</th>
+                  <th>Attack Points</th>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-runtime-isolation-policies">WoT Runtime Isolation Policies</dfn></th>
+                  <td>Access control policies for isolating co-existing system providers on the device.
+                      Not required if a simple baseline policy of "full isolation" is applied 
+                      to different WoT Runtimes running scripts from different System providers. 
+                      It might be required if some level of data sharing between them is needed. </td>
+                  <td><a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>, <a href="#dfn-system-maintainer" class="internalDFN" data-link-type="dfn">System Maintainer</a></td>
+                  <td>Storage on the thing itself, remote storage (if they are backed up to a remote storage),
+                      in-transfer for initial provisioning and policy updates</td>
+              </tr>
+          </tbody></table>
+      </section>
+
+      <section id="wot-threat-adversaries">
+      <h4 id="x3-2-3-adversaries"><bdi class="secno">3.2.3 </bdi>Adversaries<a class="self-link" aria-label="§" href="#wot-threat-adversaries"></a></h4>
+          <p>The following adversaries are in-scope for the WoT threat model: </p>
+          <table>
+              <tbody><tr>
+                  <th>Persona</th>
+                  <th>Motivation</th>
+                  <th>Attacker type</th>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-network-attacker">Network Attacker</dfn></th>
+                  <td>Unauthorized access or modification of any stakeholder's asset over the network.
+                      Denial of service. Inferring of non-public or privacy sensitive information.
+                      Taking control of the network component of a WoT System. Reasons: money, fame etc.</td>
+                  <td>Network attack: an attacker has network access to a WoT System, 
+                      is able to use WoT Interface, perform Man-in-the-Middle (MitM) attacks, 
+                      drop, delay, reorder, re-play, and inject messages. 
+                      This attacker type also includes a passive network attacker, where an attacker is only able to passively
+                      observe the WoT System traffic.</td>
+              </tr><tr>
+                  <th><dfn data-lt="malicious authorized solution user|malicious authorized solution users|malicious authorized users|Malicious Authorized User" data-dfn-type="dfn" id="dfn-malicious-authorized-solution-user">
+                      Malicious Authorized User</dfn></th>
+                  <td>Unauthorized access of private data of any other stakeholder (eavesdropping).
+                      Unauthorized modification of data of any stakeholder
+                      (modification of sensor data, or script modification).
+                      Obtaining higher privileges than originally intended by the <a href="#dfn-system-owner" class="internalDFN" data-link-type="dfn">System Owner</a>
+                      (for example, a hotel guest trying to control overall hotel lighting).</td>
+                  <td>Local physical access, WoT Consumer interface (smartphone, web interface, washing machine interface, etc.)</td>
+              </tr><tr>
+                  <th><dfn data-lt="malicious unauthorized solution user|malicious unauthorized solution users|malicious unauthorized users|Malicious Unauthorized User" data-dfn-type="dfn" id="dfn-malicious-unauthorized-solution-user">
+                      Malicious Unauthorized User</dfn></th>
+                  <td>Similar to <a href="#dfn-malicious-authorized-solution-user" class="internalDFN" data-link-type="dfn">Malicious Authorized User</a>,
+                      but with no prior access to the WoT System
+                      (examples: guests in a house, guests in a factory).
+                      Denial of service attacks on WoT System.
+</td>
+                  <td>Limited local physical network access, can use proximity factor</td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-malware-developer">Malware Developer</dfn></th>
+                  <td>Unauthorized access or modification of any stakeholder's asset.
+                      Denial of service attacks on WoT System.
+                      Taking control of WoT System network components.
+                      Reasons: money, fame etc.</td>
+                  <td>Unprivileged software adversary:
+                      application intentionally gets installed or code injected into
+                      WoT Consumer (user's smartphone, browser, etc.)
+                      or in WoT runtime itself using available WoT Interfaces</td>
+              </tr>
+          </tbody></table>
+
+          <p>The general term <dfn data-lt="malicious users|Malicious User" data-dfn-type="dfn" id="dfn-malicious-users">Malicious User</dfn> may be used to refer to either a
+             <a href="#dfn-malicious-authorized-solution-user" class="internalDFN" data-link-type="dfn">Malicious Authorized User</a> or a <a href="#dfn-malicious-unauthorized-solution-user" class="internalDFN" data-link-type="dfn">Malicious Unauthorized User</a>.</p>
+
+          <p>If a WoT System allows the co-existence of different independent System providers (tenants)
+             on a single physical device, the following adversaries are added:</p>
+          <table>
+              <tbody><tr>
+                  <th>Persona</th>
+                  <th>Motivation</th>
+                  <th>Attacker Type</th>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-malicious-system-provider">Malicious System Provider</dfn>
+                  </th><td>Tries to get access or modify other <a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Data</a>,
+                      tries to access or modify <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> from another solution provider.</td>
+                  <td>Unprivileged software adversary:
+                      <a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System provider scripts</a> running on the same HW device, but inside a different WoT runtime</td>
+              </tr>
+           </tbody></table>
+
+           <p>The following adversaries are out of scope of the WoT threat model:</p>
+           <table>
+               <tbody><tr>
+                   <th>Persona</th>
+                   <th>Motivation</th>
+                   <th>Attacker Type</th>
+               </tr><tr>
+		   <th><dfn data-dfn-type="dfn" id="dfn-malicious-oem">Malicious OEM</dfn></th>
+		   <td>Intentionally installs HW, firmware or other lower SW level backdoors,
+		       rootkits etc. 
+		       in order to get unauthorized access to WoT assets or affect WoT System in any form</td>
+		   <td>Local physical access, privileged access</td>
+	       </tr><tr>
+		   <th><dfn data-dfn-type="dfn" id="dfn-careless-oem">Careless OEM</dfn></th>
+		   <td>In order to reduce production costs substitutes security validated original
+		       HW parts with low quality unvalidated replacement parts potentially impacting security.</td>
+		   <td>Local physical access, privileged access</td>
+	       </tr><tr>
+		   <th><dfn data-dfn-type="dfn" id="dfn-careless-system-provider">Careless System Provider</dfn></th>
+		   <td>In order to reduce solution deployment costs utilizes low quality SW,
+		       performs poor testing, misconfigures hardware or software,
+		       TDs and/or access control policies.</td>
+		   <td>Local physical access, privileged access</td>
+	       </tr><tr>
+		   <th><dfn data-dfn-type="dfn" id="dfn-non-wot-end-point-attacker">Non-WoT End Point Attacker</dfn></th>
+		   <td>Tries to get authorized access/modify any asset stored at non-WoT end points
+		       (Cloud, non-WoT Devices etc.) Reasons: monetary, fame etc.</td>
+		   <td>Remote or local attack</td>
+               </tr>
+           </tbody></table>
+       </section>
+
+       <section id="wot-threat-model-attack-surfaces">
+       <h4 id="e-wot-threat-model-attack-surfaces"><bdi class="secno">3.2.4 </bdi>Attack Surfaces<a class="self-link" aria-label="§" href="#e-wot-threat-model-attack-surfaces"></a></h4>
+           <p>In order to correctly define WoT attack surfaces one needs to determine the system's
+              trust model as well as execution context boundaries. 
+              A high-level view of the WoT architecture from the security point of view is presented in
+              <a href="#wot-security-fig-attack-surfaces" class="fig-ref" title="WoT High-Level Architecture Security View">Figure <bdi class="figno">2</bdi></a>,
+              showing all possible execution boundaries.
+              However, in practice certain execution boundaries might not be present as they are 
+              dependent on the actual device implementation.</p>
+
+           <figure id="wot-security-fig-attack-surfaces">
+               <img src="images/WoTArchSecurityView.png" width="100%" title="WoT High-Level Architecture Security View">
+               <figcaption>Figure <bdi class="figno">2</bdi> <span class="fig-title">WoT High-Level Architecture Security View</span></figcaption>
+           </figure>
+
+           <p>The main execution boundaries for WoT System are:</p>
+
+           <table>
+               <tbody><tr>
+                   <th>Boundary</th>
+                   <th>Description</th>
+                   <th>Notes</th>
+               </tr><tr>
+                   <th><dfn data-dfn-type="dfn" id="dfn-script-execution-boundary">Script Execution Boundary</dfn></th>
+                   <td>Separates execution contexts between different Exposed Things.
+                       If present,
+                       this boundary should be implemented either as having different script runtime
+                       contexts (with WoT runtime isolation means) 
+                       or by having separate process execution contexts
+                       (with OS process isolation means)</td>
+                   <td>This boundary is required if we assume that WoT Runtime can run untrusted scripts 
+                   or if some scripts have a higher chance of being compromised remotely</td>
+               </tr><tr>
+                   <th><dfn data-dfn-type="dfn" id="dfn-wot-runtime-instance-execution-boundary">WoT Runtime Instance Execution Boundary</dfn></th>
+                   <td>Separates execution contexts between different WoT Runtime instances.
+                       If present,
+                       this boundary should be implemented using at least with OS process isolation,
+                       but in addition can be implemented using any stronger security measures available
+                       on the device (Mandatory Access Control, OS-kernel level virtualization,
+                       Full Virtualization etc.)</td>
+                   <td>This boundary is required if we assume that we have different <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Providers</a> 
+                       running on the same device in different WoT Runtime Instances.</td>
+               </tr><tr>
+                   <th><dfn data-dfn-type="dfn" id="dfn-wot-execution-boundary">WoT Execution Boundary</dfn></th>
+                   <td>Separates execution contexts between WoT runtime
+                       (including WoT Protocol Bindings) and the rest of the system.
+                       If present,
+                       this boundary should be implemented at least using OS process isolation,
+                       but in addition can be implemented using any stronger security measures available
+                       on the device (Mandatory Access Control, OS-kernel level virtualization,
+                       Full Virtualization etc.)</td>
+                   <td>This boundary is required if we assume that WoT Runtime might run untrusted scripts
+                       or there might be untrusted Protocol Bindings present.
+                       It is also required if a device also runs a non-WoT SW stack
+                       and elements of that stack can potentially be compromised</td>
+               </tr><tr>
+                   
+                   <th><dfn data-dfn-type="dfn" id="dfn-wot-runtime-and-protocol-bindings-execution-boundaries">WoT Runtime and Protocol Bindings Execution Boundaries</dfn></th>
+                   <td>Separate execution contexts between WoT runtime and Protocol Bindings.
+                       If present,
+                       these boundaries should be implemented at least using OS process isolation.</td>
+                   <td>These boundaries might be needed if we assume that a WoT Runtime can run untrusted scripts
+                       and would like to implement additional access control measures
+                       at the Protocol Binding level.</td>
+               </tr>
+           </tbody></table>
+
+            <p>Out of above execution boundaries, the following ones become in-scope attack surfaces
+            for the WoT security model only if we assume a WoT runtime can run untrusted scripts
+              or we assume co-existence of different <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Providers</a> (tenants)
+              on a single physical device:</p>
+           <table>
+               <tbody><tr>
+                   <th>System Element</th>
+                   <th>Compromise Type(s)</th>
+                   <th>Assets Exposed</th>
+                   <th>Attack Method</th>
+               </tr><tr>
+                   <td><a href="#dfn-script-execution-boundary" class="internalDFN" data-link-type="dfn">Script Execution Boundary</a></td>
+                   <td>Modification or unauthorized access to any asset available
+                   to other scripts.
+                   Denial of Service</td>
+                   <td><a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a>,
+                       <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a>,
+                       <a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>,
+                       <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a>,
+                       <a href="#dfn-wot-controlled-environment" class="internalDFN" data-link-type="dfn">WoT Controlled Environment</a></td>
+                   <td>Local attack by an untrusted WoT script using WoT Scripting
+                   API or any native OS local method.</td>
+               </tr><tr>
+                   <td><a href="#dfn-wot-runtime-instance-execution-boundary" class="internalDFN" data-link-type="dfn">WoT Runtime Instance Execution Boundary</a></td>
+                   <td>Modification or unauthorized access to any asset available
+                   to another WoT Runtime running on the same HW device.
+                   Denial of Service</td>
+                   <td><a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a>,
+                       <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a>,
+                       <a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>,
+                       <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a>,
+                       <a href="#dfn-wot-controlled-environment" class="internalDFN" data-link-type="dfn">WoT Controlled Environment</a></td>
+                   <td>Local attack by an untrusted WoT runtime using any native OS
+                   local method.</td>
+               </tr>
+           </tbody></table>
+           <p> While the <a href="#dfn-wot-execution-boundary" class="internalDFN" data-link-type="dfn">WoT Execution Boundary</a> is the main boundary between the WoT
+           layer and the rest of the software on a given physical device, we don't consider it
+           as in-scope attack surface for this threat model, because we are not able to define
+           security measures that prevent lower layers of device's software stack to access
+           and compromise the WoT runtime and Protocol Bindings. Such measures would greatly 
+           depend on underlying device implementation and should be considered by an OEM that
+           produces physical device and enables it for WoT usage. Similar the <a href="#dfn-wot-runtime-and-protocol-bindings-execution-boundaries" class="internalDFN" data-link-type="dfn">WoT Runtime 
+           and Protocol Bindings Execution Boundaries</a>are out of scope, because their presence
+           and implementation depends on concrete architecture of WoT runtime.</p>
+
+           <p>In addition to attack surfaces related to the execution boundaries within a
+           physical device, the following network-facing interfaces are in-scope attack surfaces
+           for this threat model:</p>
+           <table>
+               <tbody><tr>
+                   <th>System Element</th>
+                   <th>Compromise Type(s)</th>
+                   <th>Assets Exposed</th>
+                   <th>Attack Method</th>
+               </tr><tr>
+                   <th>WoT Interface</th>
+                   <td>Modification or unauthorized access to any affected asset,
+                       Unauthorized execution of exposed WoT Interfaces,
+                       Denial of Service</td>
+                   <td><a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a>,
+                       <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a>,
+                       <a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>,
+                       <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a>,
+                       <a href="#dfn-wot-controlled-environment" class="internalDFN" data-link-type="dfn">WoT Controlled Environment</a>,
+                       <a href="#dfn-wot-behavior-metrics" class="internalDFN" data-link-type="dfn">WoT Behavior Metrics</a></td>
+                   <td>Network attack</td>
+               </tr><tr>
+                   <th>WoT Protocol Bindings</th>
+                   <td>Modification or unauthorized access to any affected asset,
+                       Unauthorized execution of exposed WoT Protocol Bindings,
+                       Denial of Service</td>
+                  <td> <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a>,
+                       <a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>,
+                       <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a>,
+                       <a href="#dfn-wot-controlled-environment" class="internalDFN" data-link-type="dfn">WoT Controlled Environment</a>,
+                       <a href="#dfn-wot-behavior-metrics" class="internalDFN" data-link-type="dfn">WoT Behavior Metrics</a></td>
+                   <td>Network attack</td>
+               </tr>
+           </tbody></table>
+
+           <p>If a WoT System allows dynamic installation of scripts inside WoT runtime,
+              the following attack surfaces are added:</p>
+           <table>
+               <tbody><tr>
+                   <th>System Element</th>
+                   <th>Compromise Type(s)</th>
+                   <th>Assets exposed</th>
+                   <th>Attack Method</th>
+               </tr><tr>
+                   <th>WoT Script Management Interface. This interface, likely in practice
+                   implemented by a manager Thing (or Thing Manager), allows dynamic installation,
+                   removal and update of WoT scripts. 
+                </th>
+                   <td>Compromise of WoT scripts,
+                       including installing an older version of legitimate scripts (rollback)</td>
+                   <td><a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Scripts</a> (part of <a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Data</a>)
+                       and their execution environment</td>
+                   <td>Network attack</td>
+               </tr>
+           </tbody></table>
+
+           
+
+           <p>The following attack surfaces are currently out-of-scope for the WoT Security model:</p>
+           <table>
+               <tbody><tr>
+                   <th>System Element</th>
+                   <th>Compromise Type(s)</th>
+                   <th>Assets Exposed</th>
+                   <th>Attack Method</th>
+                   <th>Reasoning</th>
+               </tr><tr>
+                   <th>Thing Directory</th>
+                   <td>Modification or unauthorized access to hosted TDs,
+                   Denial of Service by preventing legitimate users from obtaining TDs,
+                   Inference of non-public or privacy sensitive information based on
+                   the observation of the protocol between the WoT endpoints and
+                   Things Directory.</td>
+                   <td><a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a>, history of interaction with Thing Directory</td>
+                   <td>Any remote or local attack method on a Thing Directory service
+                   that results in attacker obtaining unauthorized access or the ability
+                   to modify TDs hosted by this service or to cause any type of DoS attack
+                   on the hosting service itself. In addition public hosting of TDs by a
+                   Thing Directory can have strong privacy implications and risks, as well
+                   as obtaining information on interactions between the Thing Directory
+                   and a given WoT System setup or user</td>
+                   <td>This attack surface is out of scope because WoT specifications do
+                   not define the internal structure of Thing Directory services or their interaction
+                   protocol.</td>
+               </tr><tr>
+                  <th>Non-WoT endpoints</th>
+                   <td>Component compromise. This includes legacy devices,
+                   remote clouds and other infrastructures, user interfaces
+                   such as browsers or applications on a smartphone, etc.)</td>
+                   <td>Any type of WoT asset</td>
+                   <td>Any remote or local attack method on a non-WoT endpoint that
+                   results in an attacker obtaining unauthorized access or the ability to
+                   modify any WoT asset stored at the non-WoT endpoint or to cause any
+                   type of DoS attack on <a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a> or <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT
+                   Infrastructure Resources</a></td>
+                   <td>This attack surface is out of scope because WoT specifications do
+                   not cover non-WoT endpoints. 
+		   
+		   </td>
+               </tr><tr>
+                   <th>Native device compromise</th>
+                   <td>Device compromise on all SW or HW levels below WoT Runtime.</td>
+                   <td>Any type of the WoT assets</td>
+                   <td>Any remote or local attack method on WoT Devices on levels below WoT runtime that
+                   results in attacker obtaining unauthorized access or the ability to
+                   modify any WoT asset stored at the WoT Runtime or to cause any type
+                   of DoS attack on <a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a> or <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure
+                   Resources</a></td>
+                   <td>This attack surface is out of scope because WoT specifications do
+                   not cover levels below the WoT Runtime. 
+		   
+		   </td>
+               </tr>
+           </tbody></table>
+       </section>
+
+       <section id="wot-threat-model-threats">
+       <h4 id="x3-2-5-threats"><bdi class="secno">3.2.5 </bdi>Threats<a class="self-link" aria-label="§" href="#wot-threat-model-threats"></a></h4>
+       <p>This section lists all basic WoT threats with the exception of threats on
+       the attack surfaces that we have put out of scope in the previous section.</p>
+
+       <p>The WoT threat model assumes that the WoT Consumer
+         (which might reside on a non-WoT Device, such as a smartphone, a PC browser, etc.)
+         communicates with a WoT System using standard WoT Interfaces and WoT Protocol Bindings.
+         In order to minimize the attack surface,
+         it is strongly recommended that no other separate communication means is provided for this purpose.
+         This threat model makes the assumption that this recommendation is followed.
+         It is also assumed that WoT Protocol Bindings are trusted and cannot be installed by untrusted parties.
+
+       </p><table>
+           <tbody><tr>
+               <th>Threat</th>
+               <th>Adversary</th>
+               <th>Asset</th>
+               <th>Attack method and pre-conditions</th>
+           </tr><tr>
+               <th><dfn id="dfn-wot-protocol-binding-threat" data-dfn-type="dfn">WoT Protocol Binding Threat</dfn></th>
+               <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                   <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                   <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a></td>
+               <td>All WoT assets within the same execution boundary</td>
+               <td><strong>Pre-conditions:</strong>
+                   General preconditions for a network attacker with access to 
+		   the WoT Protocol Bindings and/or WoT Interface.
+                   In case of <a href="#dfn-malicious-authorized-solution-user" class="internalDFN" data-link-type="dfn">Malicious Authorized Solution User</a>
+                   or <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>
+                   also access to solution user credentials available on the configuration interface 
+                   (smartphone, tablet etc.)<br>
+                   <strong>Attack method:</strong>
+                   Any remote attack method using WoT Interface or directly
+                   using protocol binding interfaces with the purpose of
+                   compromising protocol binding component and access to all available WoT assets</td>
+           </tr><tr>
+               <th><dfn id="dfn-wot-interface-threat-exposed-thing-compromise" data-dfn-type="dfn">WoT Interface Threat - Exposed Thing Compromise</dfn></th>
+               <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                   <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                   <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a></td>
+               <td>All available WoT assets in the same execution boundary</td>
+               <td><strong>Pre-conditions:</strong>
+                   Same as for <a href="#dfn-wot-protocol-binding-threat" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-protocol-binding-threat-1">WoT Protocol Binding Threat</a>
+                   <strong>Attack method</strong>:
+                   Same as for <a href="#dfn-wot-protocol-binding-threat" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-protocol-binding-threat-2">WoT Protocol Binding Threat</a> with 
+		   the purpose of compromising an Exposed Thing.</td>
+           </tr><tr>
+               <th><dfn data-dfn-type="dfn" id="dfn-wot-interface-threat-unauthorized-wot-interface-access">WoT Interface Threat - Unauthorized WoT Interface Access</dfn></th>
+               <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                   <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                   <a href="#dfn-malicious-unauthorized-solution-user" class="internalDFN" data-link-type="dfn">Malicious Unauthorized Users</a>,
+                   <a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a></td>
+               <td>An asset exposed via a WoT Interface:
+                   <a href="#dfn-wot-controlled-environment" class="internalDFN" data-link-type="dfn">WoT controlled environment</a>,
+                    <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System user data</a>,
+                    non-public parts of <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a>, etc.</td>
+               <td><strong>Pre-conditions:</strong>
+                   An attacker with an access to a WoT Interface<br>
+                   <strong>Attack method:</strong>
+                   Any remote attack method using a WoT Interface
+                   with the purpose of obtaining unauthorized access to a WoT asset</td>
+           </tr><tr>
+               <th><dfn data-dfn-type="dfn" id="dfn-wot-dos-threat">WoT DoS Threat</dfn></th>
+               <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                   <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                   <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a></td>
+               <td><a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>,
+                   <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a>,
+                   Infrastructure operability</td>
+               <td><strong>Pre-conditions:</strong>
+                   General preconditions for an attacker with access to a WoT Interface<br>
+                   <strong>Attack method:</strong>
+                   Any attack method using a WoT Interface in order to 
+		   cause Denial-of-Service (DoS) to an end thing,
+                   device, service, or infrastructure
+                   (calling WoT Interface methods that require excessive processing, 
+		   sending too many messages etc.)
+                   or to disturb the service operation by intentional dropping
+                   of all or selective WoT messages</td>
+            </tr><tr>
+                <th><dfn data-dfn-type="dfn" id="dfn-wot-communication-threat-td-authenticity">WoT Communication Threat - TD Authenticity</dfn></th>
+                <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                    <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                    <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a>,
+                    <a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a></td>
+                <td>TDs authenticity in-transfer</td>
+                <td><strong>Pre-conditions:</strong>
+                    General preconditions for network attacker with access to a WoT Interface<br>
+                    <strong>Attack method:</strong>
+                    Any attack method on a <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TD</a> in-transfer with the purpose of its modification,
+                    including rolling back to an older version of that <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TD</a></td>
+            </tr><tr>
+                <th><dfn data-dfn-type="dfn" id="dfn-wot-communication-threat-td-confidentiality-and-privacy">WoT Communication Threat - TD Confidentiality and Privacy</dfn></th>
+                <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                    <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                    <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a>,
+                    <a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a></td>
+                <td>Confidential and privacy-sensitive parts of <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a> in-transfer</td>
+                <td><strong>Pre-conditions:</strong>
+                    General preconditions for network attacker with access to a WoT Interface<br>
+                    <strong>Attack method:</strong>
+                    Any attack method on TDs in-transfer with the purpose of obtaining unauthorized
+                    access to non-public parts of TDs or passively observing public parts of TDs in-transfer</td>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-communication-threat-system-user-data-authenticity">WoT Communication Threat - System User Data Authenticity</dfn></th>
+                 <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                     <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware developer</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a>,
+                     <a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a></td>
+                 <td><a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> authenticity in-transfer</td>
+                 <td><strong>Pre-conditions:</strong>
+                     General preconditions for network attacker with access to a WoT Interface<br>
+                     <strong>Attack method:</strong>
+                     Any attack method on solution data in-transfer with the purpose of its modification,
+                     including sequence of received data,
+                     its freshness and illegitimate replay</td>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy">WoT Communication Threat - System User Data Confidentiality and Privacy</dfn></th>
+                 <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                     <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a>,
+                     <a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a></td>
+                 <td><a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> confidentiality in-transfer</td>
+                 <td><strong>Pre-conditions:</strong>
+                     General preconditions for network attacker with access to a WoT Interface<br>
+                     <strong>Attack method:</strong>
+                     Any attack method on solution data in-transfer with the purpose of obtaining
+                     unauthorized access</td>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-communication-threat-side-channels">WoT Communication Threat - Side Channels</dfn></th>
+                 <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network attacker</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious users</a>,
+                     <a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a></td>
+                 <td><a href="#dfn-wot-behavior-metrics" class="internalDFN" data-link-type="dfn">WoT Behavior Metrics</a></td>
+                 <td><strong>Pre-conditions:</strong>
+                     General preconditions for network attacker with access to a WoT Interface<br>
+                     <strong>Attack method:</strong>
+                     Passive observation of WoT System and messages with the intention to learn 
+                     behavioral and operational patterns</td>
+             </tr>
+         </tbody></table>
+
+         <div class="note" id="issue-container-generatedID-1"><div role="heading" class="ednote-title marker" id="h-ednote-1" aria-level="5"><span>Editor's note</span><span class="issue-label">: Policy management threats to be added</span></div><p class="">
+             We may need to add threats related to credentials/policy management 
+	     depending on how they are exposed/stored within WoT runtime via scripting.
+	     However, currently WoT scripting is (intentionally) not able to access or manage credentials;
+	     instead they must be installed using a separate management interface
+	     during the runtime's configuration.
+         </p></div>
+
+         <p>If a WoT System allows dynamic installation of scripts inside a WoT runtime,
+            the following threats are added:</p>
+         <table>
+             <tbody><tr>
+                 <th>Threat</th>
+                 <th>Adversary</th>
+                 <th>Asset</th>
+                 <th>Attack method and pre-conditions</th>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-script-management-interface-threat-script-installation">WoT Script Management Interface Threat - Script installation</dfn></th>
+                 <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                     <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a></td>
+                 <td>Execution inside WoT Runtime (stepping stone to other further local attacks) 
+                     and all assets within WoT Runtime</td>
+                 <td><strong>Pre-conditions:</strong>
+                     General preconditions for network attacker with access to a WoT Script Management API<br>
+                     <strong>Attack method:</strong>
+                     Attacker installs its own script into WoT runtime using a WoT Script Management Interface</td>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-script-management-interface-threat-wot-runtime-compromise">WoT Script Management Interface Threat - WoT Runtime Compromise</dfn></th>
+                 <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                     <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a></td>
+                 <td>Compromise of WoT Runtime itself (stepping stone to other further local attacks) 
+			 and all assets within WoT Runtime</td>
+                 <td><strong>Pre-conditions:</strong>
+                     General preconditions for network attacker with access to the WoT Script Management API<br>
+                     <strong>Attack method:</strong>
+                     Attacker compromises WoT Runtime itself using a WoT Script Management Interface</td>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-script-management-interface-threat-dos">WoT Script Management Interface Threat - DoS</dfn></th>
+                 <td><a href="#dfn-network-attacker" class="internalDFN" data-link-type="dfn">Network Attacker</a>,
+                     <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a></td>
+                 <td><a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>, <a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a></td>
+                 <td><strong>Pre-conditions:</strong>
+                     General preconditions for network attacker with access to the WoT Script Management API<br>
+                     <strong>Attack method:</strong>
+                     Attacker misuses WoT Script Management Interface to cause DoS on things or infrastructure,
+                     including deleting or corrupting WoT scripts</td>
+             </tr>
+         </tbody></table>
+
+         <p>The general term <dfn data-dfn-type="dfn" id="dfn-wot-script-management-interface-threat">WoT Script Management Interface Threat</dfn> may be used to refer to any or all of
+             <a href="#dfn-wot-script-management-interface-threat-script-installation" class="internalDFN" data-link-type="dfn">WoT Script Management Interface Threat - Script installation</a>, 
+             <a href="#dfn-wot-script-management-interface-threat-wot-runtime-compromise" class="internalDFN" data-link-type="dfn">WoT Script Management Interface Threat - WoT Runtime Compromise</a>, or 
+             <a href="#dfn-wot-script-management-interface-threat-dos" class="internalDFN" data-link-type="dfn">WoT Script Management Interface Threat - DoS</a>.</p>
+
+         <p>If a WoT System allows co-existence of different independent <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Providers</a> (tenants) on a
+            single physical device or if WoT scripts are assumed to be untrusted,
+            the following new threats appear in addition to the above ones:</p>
+         <table>
+            <tbody><tr>
+               <th>Threat</th>
+               <th>Adversary</th>
+               <th>Asset</th>
+               <th>Attack method and pre-conditions</th>
+            </tr><tr>
+               <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-script-compromise">WoT Untrusted Script Threat - Script Compromise</dfn></th>
+               <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                   <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                   <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+               <td>Component compromise and all WoT assets within the same execution boundary</td>
+               <td><strong>Pre-conditions:</strong>
+                   An attacker has full control over a script running inside a WoT runtime either
+                   legitimately (<a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Script</a>) 
+		   or by compromising a <a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System Provider Script</a> or
+                   by installing their own script by other means.<br>
+                   <strong>Attack method:</strong>
+                   Any local attack method on another script running in the same WoT runtime that results
+                   in an attacker compromising that script and getting controls over it</td>
+            </tr><tr>
+                <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-runtime-compromise">WoT Untrusted Script Threat - Runtime Compromise</dfn></th>
+                <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                    <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                    <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                <td>Component compromise and all WoT assets within the same execution boundary</td>
+                <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                    <strong>Attack method:</strong>
+                    Any local attack method on WoT runtime itself with the intent of elevating its privileges
+                    to WoT runtime level</td>
+             </tr><tr>
+                 <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-confidentiality">WoT Untrusted Script Threat - Confidentiality</dfn></th>
+                 <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                     <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                     <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                 <td><a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System provider data</a> (scripts and configuration) confidentiality</td>
+                 <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                     <strong>Attack method:</strong>
+                     Any local attack method on another script running in the same WoT runtime that results
+                     in an attacker obtaining knowledge about a script or its configuration</td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-authenticity">WoT Untrusted Script Threat - Authenticity</dfn></th>
+                  <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                      <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                      <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                  <td><a href="#dfn-system-provider-scripts" class="internalDFN" data-link-type="dfn">System provider data</a> (scripts and configuration) authenticity</td>
+                  <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                      <strong>Attack method:</strong>
+                      Any local attack method on another script running in the same WoT runtime that results
+                      in allowing an attacker to modifying that script or its configuration,
+                      including rolling back to an older version of the script</td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-td-confidentiality-and-privacy">WoT Untrusted Script Threat - TD Confidentiality and Privacy</dfn></th>
+                  <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                      <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                      <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                  <td><a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a> confidentiality and privacy as stored on a thing</td>
+                  <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                      <strong>Attack method:</strong>
+                      Any local attack method on another script running in the same WoT runtime that results
+                      in an attacker obtaining unauthorized access 
+                      to non-public parts of <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a> or privacy sensitive parts of <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TDs</a>.</td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-td-authenticity">WoT Untrusted Script Threat - TD Authenticity</dfn></th>
+                  <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                      <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                      <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                  <td>TD authenticity as stored on a thing</td>
+                  <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                      <strong>Attack method:</strong>
+                      Any local attack method on another script running in the same WoT runtime that results
+                      in an attacker acheiving unauthorized modification of a <a href="#dfn-thing-descriptions" class="internalDFN" data-link-type="dfn">TD</a>,
+                      including rolling back to an older version of that TD</td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-system-user-data-authenticity">WoT Untrusted Script Threat - System User Data Authenticity</dfn></th>
+                  <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                      <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                      <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                  <td><a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User data</a> authenticity as stored/processed on a thing</td>
+                  <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                      <strong>Attack method:</strong>
+                      Any local attack method on another script running in the same WoT runtime that results
+                      in an attacker in being able to modify <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a>,
+                      including rolling back to an older version</td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-system-user-data-confidentiality-and-privacy">WoT Untrusted Script Threat - System User Data Confidentiality and Privacy</dfn></th>
+                  <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>,
+                      <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                      <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                  <td><a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> confidentiality as stored/processed on a thing</td>
+                  <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                      <strong>Attack method:</strong>
+                      Any local attack method on another script running in the same WoT runtime that results
+                      in an attacker getting unauthorized access to <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a></td>
+              </tr><tr>
+                  <th><dfn data-dfn-type="dfn" id="dfn-wot-untrusted-script-threat-dos">WoT Untrusted Script Threat - DoS</dfn></th>
+                  <td><a href="#dfn-malicious-system-provider" class="internalDFN" data-link-type="dfn">Malicious System Provider</a>
+                      <a href="#dfn-malware-developer" class="internalDFN" data-link-type="dfn">Malware Developer</a>,
+                      <a href="#dfn-malicious-users" class="internalDFN" data-link-type="dfn">Malicious Users</a> (if they can install their own scripts)</td>
+                  <td><a href="#dfn-thing-resource" class="internalDFN" data-link-type="dfn">WoT Thing Resources</a>,<a href="#dfn-wot-infrastructure-resource" class="internalDFN" data-link-type="dfn">WoT Infrastructure Resources</a>of another <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">system provider</a></td>
+                  <td><strong>Pre-conditions:</strong>
+                    Same as for <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a><br>
+                      <strong>Attack method:</strong> 
+                      Any local attack method with the goal of consuming things or infrastructure resources
+                      that disturb legitimate operation of co-existing <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Providers</a>.</td>
+              </tr>
+          </tbody></table>
+      </section>
+  </section>
+
+<section id="wot-security-scenarios">
+ <h3 id="x3-3-security-scenarios"><bdi class="secno">3.3 </bdi>Security Scenarios<a class="self-link" aria-label="§" href="#wot-security-scenarios"></a></h3>
+  <p>
+    Here we describe some typical high-level WoT scenarios and give practical examples of the above threats
+    for each scenario.   
+  </p>
+
+<section id="scenario-1-home-environment">
+<h4 id="x3-3-1-scenario-1-home-environment"><bdi class="secno">3.3.1 </bdi>Scenario 1 - Home Environment<a class="self-link" aria-label="§" href="#scenario-1-home-environment"></a></h4>
+
+<p>In this scenario we assume a standard home environment with a WoT System running behind a firewall NAT that
+ separates it from the rest of the Internet. However the WoT System is shared with the standard user home
+ network that contains other non-WoT Devices that have high chances of being compromised. 
+ This results in viewing these non-WoT Devices as possible network attackers 
+ with access to the WoT System and its APIs/Protocol Bindings.
+ Other assumptions: 
+ WoT scripts and protocol bindings are considered trusted; a single <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a> exists on physical
+ WoT Devices; and no dynamic installation of WoT scripts is possible.</p>
+
+<p>In this scenario the following <strong>WoT Threats</strong> are possible:</p>
+
+<table>
+<tbody><tr>
+<th><strong>Threat name</strong></th>
+<th><strong>Example(s)</strong></th>
+</tr>
+<tr>
+<td><a href="#dfn-wot-protocol-binding-threat" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-protocol-binding-threat-3">WoT Protocol Binding Threat</a></td>
+<td>A compromised application on a user smartphone connected to the same internal network as WoT Devices sends
+a malformed request to a WoT Device targeting the Protocol Bindings interface directly. 
+This malformed request causes
+the respective Protocol Binding to be compromised (e.g. by exploiting a buffer-overflow bug)
+and the attacker is able to run code with the privileges of
+the Protocol Binding on the WoT Device.</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-interface-threat-exposed-thing-compromise" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-exposed-thing-compromise-1">WoT Interface Threat - Exposed Thing Compromise</a></td>
+<td>A compromised application on a user smartphone connected to the same internal network as WoT Devices sends
+ a malformed request to a WoT Device using the WoT interface. This malformed request causes the respective 
+ Exposed Thing to be compromised and attacker is able to run code with the privileges of the Exposed Thing on
+ the WoT Device.</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-interface-threat-unauthorized-wot-interface-access" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-unauthorized-wot-interface-access-1">WoT Interface Threat - Unauthorized WoT Interface Access</a></td>
+<td>A user's party guest with network access to the same internal network as WoT Devices uses his device
+ to send a WoT interface request to a user's WoT Device for a certain resource access, for example, to get a 
+ video stream from user's video camera footage or permission to unlock some rooms in the house. Due to lack of
+ proper authentication, he is able to access this information or execute the required action (e.g. opening the 
+ targeted door).</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-communication-threat-td-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Authenticity</a></td>
+<td>A compromised application on a user smartphone connected to the same internal network as WoT Devices
+  listens to the network and intercepts a legitimate TD sent by one of the WoT Devices. Then it modifies the TD
+  to state different authentication method or authority and forwards it to the intended device. The device
+  follow the instructions in the modified TD and sends authentication request to the attacker's specified 
+  location potentially revealing its credentials, such as username and password. Similarly instead of modifying the 
+  legitimate TD, an attack might save it and use iit later on, for example when it would be updated to a newer 
+  version. Then, an attacker substitutes a new version of the TD with an older version to cause DoS to a device
+  trying to get an access to a resource. An additional reason for using an older TD might be exposing a 
+  previously available vulnerable interface that got hidden when the TD was updated to a newer version. This can 
+  be a stepping stone to conducting other attacks on the WoT System.</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a></td>
+<td>A user's party guest with network access to the same internal network as WoT Devices using his device
+ listens to the network and intercepts a legitimate TD send by one of the WoT Devices. While inspecting the TD
+ he/she learns privacy-sensitive information about the host, such as presence of medical tracking or
+ assistant equipment, name of healthcare provider company etc.
+ An example of privacy threat: a compromised application on a user smartphone connected to the same internal
+ network as WoT Devices listens for publicly broadcast TDs and sends this data to a remote attacker to build
+ a profile of devices installed in the home and their purpose.</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-communication-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Authenticity</a></td>
+<td>A user's party guest with network access to the same internal network as WoT Devices using his device
+ listens to the network and intercepts a legitimate WoT interface request to set some settings on some
+ actuator, for example the time when house doors get locked and unlocked. He then modifies the specified value
+ to the desirable one and then forwards the request to the destination WoT Device. The destination WoT Device
+ accepts incorrect settings.<br>Another attack example is a replay of a legitimate WoT interface request to
+ set a setting, for example, increase temperature of the house by a number of degrees. When repeated many
+ times, it might not only make living environment unusable, but also might damage the heating equipment.<br>Another
+ attack involves replaying an old legitimate WoT interface request that attacker intercepts while visiting the
+ user's home, such as commands to unlock doors, stop camera recordings etc. from a different time when the user
+ wants to get authorized access to the house.</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a></td>
+<td>A user's party guest with network access to the same internal network as WoT Devices using his device
+listens to the network and intercepts WoT interface exchange between legitimate entities. From that exchange 
+the guest learns privacy-sensitive information about the host, such as a data stream from his medical 
+tracking equipment, information about user's preferences in home environment, video/audio camera stream etc.
+</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a></td>
+<td>A compromised application on a user smartphone connected to the same internal network as WoT Devices sends
+  huge amount of requests to either a single WoT Device or all device available in the WoT System using 
+  directly Protocol Bindings interface or WoT interface. These requests take all the processing bandwidth of a
+  WoT Device or WoT System and make it impossible for legitimate users to communicate with WoT Devices or 
+  devices to communicate with each other. Depending on the implementation it can also lead to the case that 
+  alarm or authentication systems might be disabled and thieves get into user's house (however systems should
+  always implement "safe defaults" principle and in such cases keeps doors closed despite of inability to 
+  authenticate).
+</td>
+</tr>
+<tr>
+<td><a href="#dfn-wot-communication-threat-side-channels" class="internalDFN" data-link-type="dfn">WoT Communication Threat - Side Channels</a></td>
+<td>A compromised application on a user smartphone connected to the same internal network as WoT Devices
+ listens to the WoT System traffic. 
+ By this passive listening, he is able to infer various forms of privacy-related
+ information, such as WoT System configuration, WoT Devices that are present, 
+ network active and passive phase timing,
+ etc. 
+</td>
+</tr>
+</tbody></table>
+</section>
+ 
+<section id="scenario-2-business-corporate-environment">
+  <h4 id="x3-3-2-scenario-2-business-corporate-environment"><bdi class="secno">3.3.2 </bdi>Scenario 2 - Business/Corporate Environment<a class="self-link" aria-label="§" href="#scenario-2-business-corporate-environment"></a></h4>
+
+    <p>In this scenario we assume an office building environment shared between a number
+     of independent companies (tenants) with a shared WoT System running that controls temperature, lights, video
+     surveillance, air etc. 
+     The companies sharing the premises do not trust each other and can be viewed as potential attackers.
+     However, we assume that there is a trusted non-compromised <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>
+     that sets the WoT System through the whole building and handles the on-boarding and termination process
+     for all building tenants (making sure that after company leaves the building, all its data is not present
+     in the WoT System anymore).
+     Compared to Scenario 1 above, the main challenge here is to securely share the WoT System
+     between these companies and make sure their WoT <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> (that can include
+     highly confidential company information) is not exposed, tampered with, etc. 
+     Additionally one has to take into account the fact that a set of building tenants might change from
+     time to time, including employee turnover in each company. Therefore the WoT setup
+     must be flexible enough to start and terminate access to the WoT System promptly to both
+     companies (entire sets of users) and individuals.
+     Privacy is also important here, because companies need to make sure that the data about their
+     employees or clients is well protected, including such information as employee presence. 
+     Since we assume the presence of a trusted <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>, we can consider the WoT scripts and
+     protocol bindings to be trusted also. 
+     Similar to Scenario 1, there is only a single <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a> present on
+     physical WoT Devices, and no dynamic installation of WoT scripts are possible for simplicity.
+    </p>
+
+
+<p>In this scenario the following <strong>WoT Threats</strong> are possible:</p>
+
+    <table>
+    <tbody><tr>
+    <th><strong>Threat name</strong></th>
+    <th><strong>Example(s)</strong></th>
+    </tr>
+
+    <tr>
+    <td><a href="#dfn-wot-protocol-binding-threat" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-protocol-binding-threat-4">WoT Protocol Binding Threat</a></td>
+    <td>This attack is similar to the one described in Scenario 1 where a WoT System shares 
+     connectivity with other non-WoT Devices (smartphones, PCs, etc.). 
+     In this case a company's employee can send a malformed request to a WoT Device targeting a
+     Protocol Binding interface directly. 
+     This malformed request causes the respective Protocol Binding to be compromised and attacker
+     is able to run the code with the privileges of the Protocol Binding on the WoT Device. 
+     As a result the attacker can get any WoT asset from that device, including <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> 
+     from another company. 
+     </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-interface-threat-exposed-thing-compromise" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-exposed-thing-compromise-2">WoT Interface Threat - Exposed Thing Compromise</a></td>
+    <td>Similar to Scenario 1, but the attack can be done by an employee with network access to the
+    same internal network as WoT Devices.
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-interface-threat-unauthorized-wot-interface-access" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-unauthorized-wot-interface-access-2">WoT Interface Threat - Unauthorized WoT Interface Access</a></td>
+    <td>An employee with network access to the same internal network as WoT Devices using his device
+    sends a WoT interface request to obtain the data from a WoT video camera device located in a meeting
+    room of another company or to unlock the door to another company's office wing. Due to lack of proper
+    authentication, he is able to access this information or execute the targeted action 
+    (e.g. opening the door and getting physical access to another company's premises).
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-communication-threat-td-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Authenticity</a></td>
+    <td>Similar to Scenario 1, but the attack can be done by an employee with network access to the
+     same internal network as WoT Devices.
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a></td>
+    <td>If we assume that all Things and their TDs are standard to
+    the building, then unlike Scenario 1 we can (perhaps) assume that all info in them is public 
+    (since they relate to System provider and not system users).  However, if companies or employees
+    can add their own devices to the WoT System (for instance, wearables or desk lamps) than
+    the system may have to protect non-public TDs.
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-communication-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Authenticity</a></td>
+    <td>
+    Similar to Scenario 1, but the attack can be done by an employee with network access to the same
+    internal network as WoT Devices. In case this if the attack succeeds, an attacker may be able to control other's
+    company WoT Devices using actuator capabilities (including unlocking doors), changing important settings
+    (such as heating controls, disrupting a company's business activities) etc.
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a></td>
+    <td>
+      Similar to Scenario 1, but the attack can be done by an employee with network access to the same
+      internal network as WoT Devices. In case this if an attack succeeds, an attacker may learn other's company
+      confidential information, and get access to the privacy-sensitive information of other's company clients
+      and employees (including, for example, employee presence information).
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a></td>
+    <td>
+      An employee with network access to the same internal network as WoT Devices using his device
+      sends a huge number of requests to either a single WoT Device or all devices available in the WoT System
+      using either the Protocol Bindings interface directly or the WoT interface. 
+      These requests consume all the processing or bandwidth of a WoT Device or WoT System and make it impossible
+      for employees of other company to communicate with WoT Devices or devices to communicate with each 
+      other. Depending on the implementation it might also lead to alarm or authentication systems
+      being disabled and allowing attackers to get into other company's premises (however systems should always
+      implement "safe defaults" principle and in such cases keeps doors closed despite of inability to 
+      authenticate; but this causes the opposite problem of denying authorized users access and disrupting
+      legitimate business).
+    </td>
+    </tr>
+    <tr>
+    <td><a href="#dfn-wot-communication-threat-side-channels" class="internalDFN" data-link-type="dfn">WoT Communication Threat - Side Channels</a></td>
+    <td>Similar to Scenario 1, but the attack can be done by an employee with network access to the
+    same internal network as WoT Devices.
+    </td>
+    </tr>
+    </tbody></table>
+
+  </section>
+
+  <section id="scenario-3-industrial-critical-infrastructure-environment">
+   <h4 id="x3-3-3-scenario-3-industrial-critical-infrastructure-environment"><bdi class="secno">3.3.3 </bdi>Scenario 3 - Industrial/Critical Infrastructure Environment<a class="self-link" aria-label="§" href="#scenario-3-industrial-critical-infrastructure-environment"></a></h4>
+
+   <p>In this scenario we assume an industrial factory or infrastructure (power plant, water distribution
+     system, etc.) environment that is using WoT System 
+     to monitor or perform certain automation tasks in its Operational Technology (OT) network.
+     Compared to other scenarios above, the main challenge here is to guarantee safety and availability
+     of the critical infrastructure. 
+     Therefore, for example, Denial-Of-Service attacks must be mitigated as well as possible. 
+     On the other hand, privacy is usually less important for this scenario. 
+    </p>
+    <p>
+     Similar to the previous scenarios, we assume that there is a trusted non-compromised <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a>
+     that sets up the WoT System, so we can consider all WoT scripts and protocol bindings to be
+     trusted also. 
+     We also assume there is only a single <a href="#dfn-system-provider" class="internalDFN" data-link-type="dfn">System Provider</a> present on physical WoT Devices and
+     a single tenant on all system, and assume no
+     dynamic installation of WoT scripts is possible for simplicity.
+    </p>
+    <p>
+     Due to the high safety and availability requirements in the industrial environment, 
+     typically the WoT System (part of a bigger OT network) won't be shared with other tenants of the same
+     building and normally won't be shared with the general IT network of the same company.
+     The IT network is where all other company operations are happening, for example, accounting. 
+     We also don't expect factory employees to browse the internet in the coffee break using the OT network
+     (and ideally not the IT network; in some companies, a third network is even provided for employee personal use 
+     or for less-trusted personal devices.) 
+     However, usually some bridging must be present between the OT
+     and IT networking in order to support monitoring requirements, so these networks are not fully isolated. 
+     In this scenario, 
+     the risk of compromised devices and applications interacting with the WoT System is limited 
+     but nonetheless present.
+     Therefore the usual WoT threats, described in the previous scenarios, still apply, if a malicious
+     application or device gets into the industrial OT WoT System. 
+    </p>
+    <p>
+     Also, a factory employee with authorized access to
+     the OT WoT System can be also viewed as a potential attacker. 
+     The additional security challenge in this case is role management, i.e. distribution of authorized
+     accesses between the actors (factory employees, devices with actuators, etc.) in such a way that a single
+     misbehaving actor does not have enough authorization to endanger the safety and availability of the whole
+     infrastructure. 
+     Similar to the case in Scenario 2, the ability to promptly terminate an employees’ access rights to the 
+     WoT System when necessary, and without disrupting other activities, is essential. 
+    </p>
+
+   </section>
+  </section>
+
+</section>
+
+<section id="wot-privacy">
+      <h2 id="x4-privacy-considerations"><bdi class="secno">4. </bdi>Privacy Considerations<a class="self-link" aria-label="§" href="#wot-privacy"></a></h2>
+            <p>              
+              In this section we focus specifically on the privacy aspects that are important to keep in mind
+              while developing and deploying WoT solutions. 
+	      The threat model, described in <a href="#wot-threat-model" class="sec-ref">§&nbsp;<bdi class="secno">3.2 </bdi>Threat Model</a>,
+              already takes into account numerous privacy-related threats and aspects.
+	      However, this section summarizes them and gives guidelines
+              and recommendations specifically aimed at minimizing privacy-related risks. 
+            </p>
+            <p>              
+              The following WoT privacy threats can potentially affect the privacy of WoT <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">system users</a>:              
+             </p><table>
+                <tbody><tr>
+                <th><strong>Privacy threat name</strong></th>
+                <th><strong>Details</strong></th>
+                <th><strong>Mitigation</strong></th>
+                </tr>
+                <tr>
+                 <td><dfn data-dfn-type="dfn" id="dfn-disclosing-wot-thing-device-configuration">Disclosing WoT Thing/Device configuration</dfn></td>
+                 <td> Thing Descriptions (TDs) might leak privacy-sensitive information, such as
+                      detailed configuration of a single WoT Thing.</td>
+                 <td>WoT TDs should minimize the amount
+                      of information that is publicly available about a WoT Thing.
+                      There has to be a way (if a TD is privacy-sensitive) to limit clients who can
+                      obtain a certain TD (or its privacy-sensitive parts) via authentication and
+                      authorization methods. 
+		      It is also possible to expose a number of TD variants
+                      for the same WoT Thing based on the level of client's access.  
+                      This recommendation corresponds to the data minimization
+                      and security (unauthorized usage, peer entity authentication and confidentiality)
+                      treat mitigation strategies outlined in 
+		      [<cite><a class="bibref" data-link-type="biblio" href="#bib-coo13" title="Privacy Considerations for Internet Protocols">Coo13</a></cite>] - <cite>Privacy Considerations for Internet Protocols</cite>.
+                      </td>
+                </tr>
+                <tr>
+                 <td><dfn data-dfn-type="dfn" id="dfn-disclosing-wot-system-configuration">Disclosing WoT System configuration</dfn></td>
+                 <td> Privacy-sensitive information might be inferred via observing the communication
+                      between a WoT endpoint (Client, Servient or Device) and a Thing Directory.
+                      For example one can learn information about the configuration of a target
+		      WoT System by observing the TDs
+                      that the target WoT System downloads from a Thing Directory. 
+                      In addition, loading JSON-LD context files might also leak WoT System configuration.
+		      For example, context files may be used to allow TDs to be extended with
+		      new protocols and security schemes; loading these context files then
+		      implies the TDs uses these protocols or schemes. </td>
+                 <td>The communication between WoT endpoints and a TD distribution service (i.e. Thing
+                      Directories) should be protected against eavesdroppers using well-established
+                      security protocols. It also should not be possible for a casual observer
+                      (for example, a guest visiting a person's home with access to a private wireless access point)
+                      to query available WoT Devices (there has to be a way to limit WoT Devices'
+                      ability to respond to different broadcast events) and as a result obtaining
+                      WoT System configuration. 
+                      Caching on gateways can help with the JSON-LD context files loading problem.  
+                      This recommendation corresponds to the data minimization
+                      and security (unauthorized usage, peer entity authentication and confidentiality)
+                      treat mitigation strategies outlined in 
+                      [<cite><a class="bibref" data-link-type="biblio" href="#bib-coo13" title="Privacy Considerations for Internet Protocols">Coo13</a></cite>] - <cite>Privacy Considerations for Internet Protocols</cite>. </td>
+                </tr>
+                <tr>
+                 <td><dfn data-dfn-type="dfn" id="dfn-leaking-wot-system-user-data">Leaking WoT System User Data</dfn></td>
+                 <td> Depending on the network topology, WoT <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> can be transferred
+                      between the WoT Consumer and WoT Thing via many intermediate nodes, such as an Intermediary (WoT
+                      Servient) or non-WoT nodes. If these nodes can access or process the WoT
+                      <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">system user data</a>, they can unintentionally leak information impacting
+                      the privacy of WoT <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System Users</a>. 
+		      In addition, if WoT interfaces are publicly
+                      accessible (for example allowing anyone to query the state of WoT Thing), 
+		      it can also leak WoT
+                      <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a>.</td>
+                 <td>WoT Things should minimize publicly accessible WoT interfaces.
+                      If WoT System User Data is privacy-sensitive and travels via intermediate
+                      nodes, end-to-end encryption methods and object level security should be preferred. 
+		      This recommendation 
+                      corresponds to the data minimization and security (inappropriate usage,
+                      unauthorized usage and confidentiality) treat mitigation strategies outlined in 
+                      [<cite><a class="bibref" data-link-type="biblio" href="#bib-coo13" title="Privacy Considerations for Internet Protocols">Coo13</a></cite>] - <cite>Privacy Considerations for Internet Protocols</cite>.</td>
+                </tr>
+                <tr>
+                 <td><dfn data-dfn-type="dfn" id="dfn-tracking-wot-system-user">Tracking WoT System User</dfn></td>
+                 <td> According to the WoT specification, each TD includes a unique identifier (id), but it
+                      is not specified how such identifier should be generated and the duration of its 
+		      validity.
+                      Typically such identifiers are generated using various methods outlined in
+                      [<cite><a class="bibref" data-link-type="biblio" href="#bib-lea05" title="A Universally Unique IDentifier (UUID) URN Namespace">Lea05</a></cite>] - <cite>A Universally Unique IDentifier (UUID) URN Namespace</cite>.
+                      If this identifier is a persistent unique identifier that is never changed during device 
+                      lifecycle (immutable) or changed very rarely (for example only when a WoT System is
+                      installed and bootstrapped), then a WoT Device and a WoT <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System User</a> might
+                      be uniquely identified and its communications tracked.
+                      Similar tracking can be done even without identifiers by using 
+		      fingerprinting techniques based on
+                      a WoT System configuration information (which is likely to be unique).</td>
+                 <td>A TD should avoid exposing publically any persistent unique identifiers 
+		      (especially immutable ones)
+                      that can be used to track it. 
+		      Ideally, a TD's identifier (id) should be changed
+                      periodically (potentially even every time the WoT Exposed Thing is created, if it does
+                      not infer the normal operation mode of a WoT Thing).
+		      This however conflicts with the needs of Linked Data and the registration of 
+		      Things in directories and their use by other Things.  
+		      A compromise needs to be struck.  Mechanisms to notify
+		      legitimate users of a Thing when a Thing's identifier has changed may be considered
+		      if frequent updates are necessary.
+		      It should be at least possible to change a Thing's identifier
+		      by re-provisioning the device if necessary.
+                      Using methods to limit disclosure of WoT System configuration and TDs also helps to prevent
+                      tracking of WoT System users.</td>
+                </tr>
+             </tbody></table>
+             In addition to the mitigations described above, it is also important to keep <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System Users</a>
+             informed about the information that can be exposed and/or collected about them, as well as to have
+             a way for <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System Users</a> to control the degree of such exposure. 
+	     This recommendation
+             corresponds to the user participation in treat mitigation strategy outlined in 
+             [<cite><a class="bibref" data-link-type="biblio" href="#bib-coo13" title="Privacy Considerations for Internet Protocols">Coo13</a></cite>] - <cite>Privacy Considerations for Internet Protocols</cite>.
+            <p></p>
+
+          <div class="note" id="issue-container-generatedID-2"><div role="heading" class="ednote-title marker" id="h-ednote-2" aria-level="3"><span>Editor's note</span><span class="issue-label">: Links</span></div><p class="">
+            We need to mention privacy risks associated with links.
+	    In particular, dereferencing links carries similar inferencing risks
+	    as context file dereferencing.
+            This has been mentioned in the Security and Privacy 
+            sections of [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>] and 
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">WoT-Thing-Description</a></cite>] but needs to be expanded upon here.
+          </p></div>
+
+        </section>
+    
+
+  <section id="security-provisioning-onboarding-and-maintenance">
+  <h2 id="x5-security-provisioning-onboarding-and-maintenance"><bdi class="secno">5. </bdi>Security Provisioning(Onboarding) and Maintenance<a class="self-link" aria-label="§" href="#security-provisioning-onboarding-and-maintenance"></a></h2>
+    <section id="goals-and-requirements">
+    <h3 id="x5-1-goals-and-requirements"><bdi class="secno">5.1 </bdi>Goals and requirements<a class="self-link" aria-label="§" href="#goals-and-requirements"></a></h3>
+    <p>   
+    Following the lifecycle diagram  <a href="#wot-lifecycle" class="fig-ref" title="WoT Device Lifecycle">Figure <bdi class="figno">1</bdi></a> , 
+    the purpose of the Security provisioning
+    is that upon its completion a WoT Device is equipped with the security metadata
+    and credentials it needs during its Operational state.
+    The exact set of necessary credentials
+    will vary based on the WoT Device's deployment model and choice of security
+    mechanisms. The document The State-of-the-Art and Challenges for the Internet
+    of Things Security [<cite><a class="bibref" data-link-type="biblio" href="#bib-garcia17" title="State-of-the-Art and Challenges for the Internet of Things Security">Garcia17</a></cite>] refers to this stage as "Bootstrapping".
+    </p>
+
+    <p>
+    The purpose of the Security maintenance is maintaining security level set
+    during the security provisioning phase,
+    i.e. security-related configuration updates, such as key rotation or
+    certificate refresh. This also includes the actions to be taken in case of 
+    credential compromise, i.e. key revocation.
+    </p>
+
+    Security provisioning usually consists of three main stages outlined below. 
+    The WoT adds WoT-specific stage at the end:
+    <ul>
+      <li><strong>Initial enablement.</strong> During manufacturing a device is provisioned with the
+      necessary credentials that enable secure mutual authentication and remote attestation in the next step.</li> 
+      <li><strong> Mutual trust establishment.</strong> Establishing mutual trust between the device to be provisioned
+      and the provisioning entity.  Note that the provisioning entity is not necessary (and quite commonly not)
+      a manufacturer, but some service provider or service domain owner. 
+      This includes mutual authentication and authorization for both device and provisioning entity and
+      potentially remote attestation of device.</li> 
+      <li><strong> Runtime credential provisioning.</strong> The actual provisioning of credentials for the operational
+       phase in a secure fashion between the provisioning entity and the device.</li>
+       <li><strong> WoT specific provisioning.</strong> Installing the provisioned secrets and made them available and
+        ready to use on the WoT level (within the WoT Runtime)</li>
+    </ul>
+
+    <div class="note" id="issue-container-generatedID-3"><div role="heading" class="ednote-title marker" id="h-ednote-3" aria-level="4"><span>Editor's note</span><span class="issue-label">: Question1</span></div><p class="">
+    Do we try to describe only the bootstrapping of the credentials 
+    into a WoT run time (after which it can be transparently used during operational
+    phase) or do we go into describing of how credentials will end up in the physical
+    device at the first place, and then how they can be securely retrieved and embedded into
+    WoT run time? 
+    </p></div>
+    <div class="note" id="issue-container-generatedID-4"><div role="heading" class="ednote-title marker" id="h-ednote-4" aria-level="4"><span>Editor's note</span><span class="issue-label">: Question2</span></div><p class="">
+    Do we limit ourselves to the case of a single tenant (single security domain device joins
+    and accepts credentials from a single provisioning entity) or we also take multiple tenants in
+    the scope from beginning? 
+    </p></div>
+
+    </section>
+    <section id="existing-approaches">
+    <h3 id="x5-2-existing-approaches"><bdi class="secno">5.2 </bdi>Existing approaches<a class="self-link" aria-label="§" href="#existing-approaches"></a></h3>
+
+    <div class="note" id="issue-container-generatedID-5"><div role="heading" class="ednote-title marker" id="h-ednote-5" aria-level="4"><span>Editor's note</span><span class="issue-label">: Question3</span></div><p class="">
+        I guess we dont want to consider old style approaches as "ask user to input manually smth"
+    or "connect to manufacturer to fetch credentials via manufacturer service"?
+    </p></div>
+    <section id="bootstrapping-remote-secure-key-infrastructures-brski">
+     <h4 id="x5-2-1-bootstrapping-remote-secure-key-infrastructures-brski"><bdi class="secno">5.2.1 </bdi>Bootstrapping Remote Secure Key Infrastructures (BRSKI)<a class="self-link" aria-label="§" href="#bootstrapping-remote-secure-key-infrastructures-brski"></a></h4>
+        The draft IETF standard [<cite><a class="bibref" data-link-type="biblio" href="#bib-pri19" title="Bootstrapping Remote Secure Key Infrastructures (BRSKI)">Pri19</a></cite>]
+    </section>
+    <section id="intel-secure-device-onboard-sdo">
+     <h4 id="x5-2-2-intel-secure-device-onboard-sdo"><bdi class="secno">5.2.2 </bdi>Intel Secure Device Onboard (SDO)<a class="self-link" aria-label="§" href="#intel-secure-device-onboard-sdo"></a></h4>
+        Intel technology overview [<cite><a class="bibref" data-link-type="biblio" href="#bib-sdo" title="Intel® Secure Device Onboard">SDO</a></cite>]
+     </section>
+    </section>
+  </section>
+
+  <section id="references-to-existing-security-best-practices">
+  <h2 id="x6-references-to-existing-security-best-practices"><bdi class="secno">6. </bdi>References to Existing Security Best Practices<a class="self-link" aria-label="§" href="#references-to-existing-security-best-practices"></a></h2>
+    <p>
+      Best practices in security are constantly evolving,
+      and it is important to keep up to date.
+      At the same time,
+      IoT is new enough and is itself evolving rapidly enough that best practices
+      are just now emerging and are likely to require rapid updating.  
+      Recently attempts have been made to document and categorize useful approaches to security in IoT.
+      The following are some of the more useful points of reference:
+      </p><ul>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-garcia17" title="State-of-the-Art and Challenges for the Internet of Things Security">Garcia17</a></cite>] - <cite>State-of-the-Art and Challenges for the Internet of Things Security</cite>:<br>
+      This IETF document, a product of the IETF T2TRG, is still in draft form but is now a candidate for
+      ratification. 
+      It covers a range of recommendations for securing IoT systems.  
+      Readers should look for the latest version using the IETF RFC tracker.</li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-iicsf16" title="The Industrial Internet of Things Volume G4: Security Framework">IicSF16</a></cite>] - <cite>The Industrial Internet of Things Volume G4: Security Framework</cite>:<br>
+      Focuses on industrial IoT systems and use cases, and so as discussed above
+      emphasizes safety over privacy considerations.
+      However, this document includes many practices that are also relevant to other IoT use cases.
+      </li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-ietface" title="IETF Authentication and Authorization for Constrained Environments (ACE)">IETFACE</a></cite>] - <cite>IETF Authentication and Authorization for Constrained Environments (ACE)</cite>:<br>
+      Discusses the use of existing IETF standards for constrained environments 
+      (such as CoAP and DTLS) of relevance to IoT.
+      This working group defines building blocks for IoT security esp. addressing authentication and authorization.
+      </li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-isf17" title="IoT Security Foundation Best Practice Guidelines">ISF17</a></cite>] - <cite>IoT Security Foundation Best Practice Guidelines</cite>:<br>
+      A general set of recommendations for managing the security of IoT systems,
+      including lifecycle management.
+      </li>
+      </ul>
+    <p></p><p>
+      Here are some additional general references for threat modeling and security architecture planning.
+      These frameworks can be helpful when designing the security architecture of a specific IoT system or 
+      standard.  OWASP in particular is useful for Things using the HTTP protocol for their network interface.
+      </p><ul>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-mic17" title="Internet of Things security architecture">Mic17</a></cite>] - <cite>STRIDE - Internet of Things security architecture</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-nis15" title="Guide to Industrial Control Systems (ICS) Security">Nis15</a></cite>] - <cite>NIST Guide to Industrial Control Systems (ICS) Security</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-owa17" title="Threat Risk Modeling">Owa17</a></cite>] - <cite>OWASP Threat Risk Modeling</cite></li>
+      </ul>
+    <p></p><p>
+      The following documents define the security and privacy considerations 
+      that should be included in internet standards.
+      These references helped define the topics covered in this document.
+      </p><ul>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-coo13" title="Privacy Considerations for Internet Protocols">Coo13</a></cite>] - <cite>Privacy Considerations for Internet Protocols</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-res03" title="Guidelines for Writing RFC Text on Security Considerations">Res03</a></cite>] - <cite>IETF Guidelines for Writing RFC Text on Security Considerations</cite></li>
+      </ul>
+    <p></p><div class="note" id="issue-container-generatedID-6"><div role="heading" class="ednote-title marker" id="h-ednote-6" aria-level="3"><span>Editor's note</span><span class="issue-label">: Elaborate on additional references and/or cull</span></div><p class="">
+          The references below are relevant,
+          but the text should explain them more, categorize them, and put them in context.
+          Also, we don't necessarily need all of these, and may need others not listed.
+    </p></div><p>
+      Additional references:
+      </p><ul>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-core-rd" title="CoRE Resource Directory">CoRE-RD</a></cite>] - <cite>CoRE Resource Directory</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-bel89" title="Security Problems in the TCP-IP Protocol Suite">Bel89</a></cite>] - <cite>Security Problems in the TCP-IP Protocol Suite</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-bel13" title="Web Security in the Real World">Bel13</a></cite>] - <cite>Web Security in the Real World</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-ber14" title="Authentication Protocols, Web UX and Web API">Ber14</a></cite>] - <cite>Authentication Protocols, Web UX and Web API</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-bor14" title="Terminology for Constrained-Node Networks">Bor14</a></cite>] - <cite>Terminology for Constrained-Node Networks</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-bru14" title="Using Frankencerts for Automated Adversarial Testing of Certificate Validation in SSL/TLS Implementations">Bru14</a></cite>] - <cite>Using Frankencerts for Automated Adversarial Testing of Certificate Validation in SSL/TLS Implementations</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-dur13" title="Analysis of the HTTPS Certificate Ecosystem">Dur13</a></cite>] - <cite>Analysis of the HTTPS Certificate Ecosystem</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-ell00" title="Ten Risks of PKI: What You’re not Being Told about Public Key Infrastructure">Ell00</a></cite>] - <cite>Ten Risks of PKI: What You’re not Being Told about Public Key Infrastructure</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-fu01" title="Dos and Don’ts of Client Authentication on the Web">Fu01</a></cite>] - <cite>Dos and Don’ts of Client Authentication on the Web</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-geo12" title="The Most Dangerous Code in the World: Validating SSL Certificates in Non-Browser Software">Geo12</a></cite>] - <cite>The Most Dangerous Code in the World: Validating SSL Certificates in Non-Browser Software</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-gol03" title="Cryptography and Cryptographic Protocols">Gol03</a></cite>] - <cite>Cryptography and Cryptographic Protocols</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-gre14" title="How do you know if an RNG is working?">Gre14</a></cite>] - <cite>How do you know if an RNG is working?</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-gut02" title="PKI: It’s Not Dead, Just Resting">Gut02</a></cite>] - <cite>PKI: It’s Not Dead, Just Resting</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-hea13" title="An update on our war against account hijackers">Hea13</a></cite>] - <cite>An update on our war against account hijackers</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-iic15" title="Industrial Internet Reference Architecture">Iic15</a></cite>] - <cite>Industrial Internet Reference Architecture</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-iicra17" title="The Industrial Internet of Things Volume G1: Reference Architecture">IicRA17</a></cite>] - <cite>The Industrial Internet of Things Volume G1: Reference Architecture</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-jon14" title="A JSON-Based Identity Protocol Suite">Jon14</a></cite>] - <cite>A JSON-Based Identity Protocol Suite</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-ken03" title="Who Goes There? Authentication Through the Lens of Privacy">Ken03</a></cite>] - <cite>Who Goes There? Authentication Through the Lens of Privacy</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-lam04" title="Computer Security in the Real World">Lam04</a></cite>] - <cite>Computer Security in the Real World</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-loc05" title="Demystifying SAML">Loc05</a></cite>] - <cite>Demystifying SAML</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-mel15" title="Securing the Industrial Internet of Things">Mel15</a></cite>] - <cite>Securing the Industrial Internet of Things</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-moo02" title="A critical review of End-to-end arguments in system design">Moo02</a></cite>] - <cite>A critical review of End-to-end arguments in system design</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-oos10" title="Provisioning scenarios in identity federations">Oos10</a></cite>] - <cite>Provisioning scenarios in identity federations</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-sch14" title="The Internet of Things Is Wildly Insecure — And Often Unpatchable">Sch14</a></cite>] - <cite>The Internet of Things Is Wildly Insecure — And Often Unpatchable</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-sch99" title="Breaking Up Is Hard To Do: Modeling Security Threats for Smart Cards">Sch99</a></cite>] - <cite>Breaking Up Is Hard To Do: Modeling Security Threats for Smart Cards</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-she14" title="The Constrained Application Protocol (CoAP)">She14</a></cite>] - <cite>The Constrained Application Protocol (CoAP)</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-vol00" title="AAA Authorization Framework">Vol00</a></cite>] - <cite>AAA Authorization Framework</cite></li>
+      <li>[<cite><a class="bibref" data-link-type="biblio" href="#bib-yeg11" title="Stevey's Google Platforms Rant">Yeg11</a></cite>] - <cite>Stevey's Google Platforms Rant</cite></li>
+      </ul>
+    <p></p><div class="note" id="issue-container-generatedID-7"><div role="heading" class="ednote-title marker" id="h-ednote-7" aria-level="3"><span>Editor's note</span><span class="issue-label">: Use global database for RFC references</span></div><p class="">
+          Should use references from global ReSpec bibliography whenever possible,
+          rather than local bibliographic entries.
+    </p></div>
+  </section>
+
+  <section id="security-mitigations">
+  <h2 id="x7-best-security-practices-and-mitigations-for-wot-systems"><bdi class="secno">7. </bdi>Best Security Practices and Mitigations for WoT Systems<a class="self-link" aria-label="§" href="#security-mitigations"></a></h2>
+      <p>
+        Based on the main WoT assets, 
+	privacy and security threats listed in <a href="#wot-threat-model-assets" class="sec-ref">§&nbsp;<bdi class="secno">3.2.2 </bdi>Assets</a>, 
+	<a href="#wot-threat-model-threats" class="sec-ref">§&nbsp;<bdi class="secno">3.2.5 </bdi>Threats</a> and
+        <a href="#wot-privacy" class="sec-ref">§&nbsp;<bdi class="secno">4. </bdi>Privacy Considerations</a>, we provide here a set of recommended practices for
+        enhancing security and privacy when designing a WoT System.
+	Depending on the usage scenario, these may not be adequate for securing
+	any given WoT System, however.  The full threat model should be 
+	considered to identify and mitigate any additional threats for 
+	a specific WoT System.
+      </p>
+
+      <section id="secure-practices-for-designing-a-thing-description">
+        <h3 id="x7-1-secure-practices-for-designing-a-thing-description"><bdi class="secno">7.1 </bdi>Secure Practices for designing a Thing Description<a class="self-link" aria-label="§" href="#secure-practices-for-designing-a-thing-description"></a></h3>
+
+         <p><strong>Secure Delivery and Storage of Thing Description.</strong></p>
+         <p>            
+    	      When a TD is transferred between WoT endpoints, to or from the TD
+              hosting service, it is important to use secure protocols guaranteeing
+    	      data authenticity, freshness and in many cases confidentiality 
+              (depending on whenever a TD contains any confidential or
+              privacy-sensitive information). 
+	      TDs should not be provided without first authenticating the requester
+	      and checking that they have authorization to access the requested TDs.
+	      If end-to-end TD authenticity or
+              confidentiality is required, see <a href="#sec-pract-end-to-end-security" class="sec-ref">§&nbsp;<bdi class="secno">7.4 </bdi>Secure Practices for End-to-End security</a>
+              for more specific guidance. 
+              When a TD is stored at the end device, in a gateway (e.g. in a cache or directory
+	      service) or in remote storage (e.g. an archive),
+              its authenticity and in some cases confidentiality should
+              also be protected using the best available local methods. 
+            </p>
+            <p>
+  	      This recommendation helps prevent the following threats: 
+              <a href="#dfn-wot-communication-threat-td-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Authenticity</a>,
+              <a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a>,
+              <a href="#dfn-disclosing-wot-thing-device-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT Thing/Device configuration</a>,
+              <a href="#dfn-disclosing-wot-system-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT System configuration</a>,
+              <a href="#dfn-tracking-wot-system-user" class="internalDFN" data-link-type="dfn">Tracking WoT System User</a>.
+            </p>
+
+         <p><strong>Avoid Exposing Persistent Unique Identifiers</strong></p>
+            <p>
+             When defining fields exposed by a TD immutable information should be avoided,
+	     especially if that information can be tied to a particular person or 
+	     is associated with personally identifiable information.
+             It is specifically strongly recommended to avoid exposing 
+	     any immutable hardware identifiers.
+             Instead it is recommended to use "soft identifiers", 
+	     i.e. identifiers that can be changed at some point during the device's lifecycle.
+	     Given the requirements of Linked Data, it may not be possible to change
+	     the identifier during the Operational state of a device without additional
+	     infrastructure to register consumers of a TD and notify them of updates, but it should 
+	     at least be possible during (re-)provisioning.
+            </p>
+            <p>
+            This recommendation helps prevent the following threats: 
+            <a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a>,
+            <a href="#dfn-disclosing-wot-system-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT System configuration</a>,
+            <a href="#dfn-tracking-wot-system-user" class="internalDFN" data-link-type="dfn">Tracking WoT System User</a>.
+            </p>
+
+         <p><strong>Minimize Publicly Exposed Information in TD</strong></p>
+            <p>
+             WoT TDs should minimize the amount of information that
+             is publicly available about a WoT Thing.             
+	     For example, the TD should generally not identify the version of the software or
+	     operating system a device is running, since this information can be used
+	     to identify vulnerable systems.  
+	     Instead the TD should capture all information
+	     needed to support interoperability without reference to particular implementations.
+            </p>
+            <p>
+            This recommendation helps prevent the following threats: 
+            <a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a>,
+            <a href="#dfn-disclosing-wot-thing-device-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT Thing/Device configuration</a>,
+            <a href="#dfn-disclosing-wot-system-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT System configuration</a>,
+            <a href="#dfn-tracking-wot-system-user" class="internalDFN" data-link-type="dfn">Tracking WoT System User</a>,
+            <a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a>.
+            </p>
+
+         <p><strong>Limit TDs exposure</strong></p>
+            <p>
+             Limit clients who can obtain a certain TD (or its privacy-sensitive parts)
+             via authentication and authorization methods.
+             This can be done by exposing a number of TD variants for the same 
+             WoT Thing based on the level of client’s access.           
+	     For example, versions of a TD for "public access" may be generated with a subset
+	     of information in the full TD, omitting (for example) support or version metadata.
+            </p>
+            <p>
+            This recommendation helps prevent the following threats: 
+            <a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a>,
+            <a href="#dfn-disclosing-wot-thing-device-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT Thing/Device configuration</a>,
+            <a href="#dfn-tracking-wot-system-user" class="internalDFN" data-link-type="dfn">Tracking WoT System User</a>,
+            <a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a>.
+            </p>
+   </section>
+
+    <section id="sec-pract-system-user-data">
+        <h3 id="x7-2-secure-practices-for-protecting-system-user-data"><bdi class="secno">7.2 </bdi>Secure Practices for protecting System User Data<a class="self-link" aria-label="§" href="#sec-pract-system-user-data"></a></h3>
+
+        <p><strong>Use Secure Transports</strong></p>
+            <p> 
+             When defining protocols for APIs exposed by a TD, 
+             it is often important to use secure protocols guaranteeing
+             <a href="#dfn-system-user-data" class="internalDFN" data-link-type="dfn">System User Data</a> authenticity and confidentiality.
+	     Specifically, HTTP-over-TLS (HTTPS), CoAP-over-DTLS (COAPS), and
+	     MQTT-over-TLS (MQTTS) should be used if any kind of authentication 
+	     or secure access is required.
+             If data travels over many intermediate nodes (potentially malicious
+             or not privacy-preserving), end-to-end encryption
+             methods should be preferred.
+            </p>
+            <p>
+            This recommendation helps prevent the following threats: 
+            <a href="#dfn-wot-communication-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Authenticity</a>,
+            <a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a>,
+            <a href="#dfn-leaking-wot-system-user-data" class="internalDFN" data-link-type="dfn">Leaking WoT System User Data</a>.
+            </p>
+ 
+        <p><strong>User Consent</strong></p>
+            <p> 
+            Keep&nbsp;<a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System Users</a>&nbsp;informed about the information that can
+            be exposed or collected about them.
+            Provide a way for <a href="#dfn-system-user" class="internalDFN" data-link-type="dfn">System Users</a>&nbsp;to control the degree of such exposure.
+            </p>
+            <p>
+            This recommendation helps prevent the following threats:
+            <a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a>,
+            <a href="#dfn-leaking-wot-system-user-data" class="internalDFN" data-link-type="dfn">Leaking WoT System User Data</a>.
+            </p>
+      </section>
+
+    
+   <section id="sec-pract-wot-interfaces">
+      <h3 id="x7-3-secure-practices-for-designing-wot-interfaces"><bdi class="secno">7.3 </bdi>Secure Practices for designing WoT Interfaces<a class="self-link" aria-label="§" href="#sec-pract-wot-interfaces"></a></h3>
+
+         <p><strong>Use Appropriate Access Control Schemes</strong></p>
+            <p>
+              Use Security Metadata options to configure appropriate
+              authentication and authorization methods for WoT Interfaces
+              exposed by a WoT Thing. 
+	      Minimize the amount of WoT Interfaces
+              without any access control defined (including emitting public
+              events). 
+              Consider different levels of access for different users.
+            </p>
+            <p>
+             This recommendation helps prevent the following threats: 
+             <a href="#dfn-wot-interface-threat-unauthorized-wot-interface-access" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-unauthorized-wot-interface-access-3">WoT Interface Threat - Unauthorized WoT Interface Access</a>,
+             <a href="#dfn-wot-interface-threat-exposed-thing-compromise" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-exposed-thing-compromise-3">WoT Interface Threat - Exposed Thing Compromise</a>,
+             <a href="#dfn-wot-communication-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Authenticity</a>,
+             <a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a>,
+             <a href="#dfn-leaking-wot-system-user-data" class="internalDFN" data-link-type="dfn">Leaking WoT System User Data</a>,
+             <a href="#dfn-disclosing-wot-thing-device-configuration" class="internalDFN" data-link-type="dfn">Disclosing WoT Thing/Device configuration</a>,
+             <a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a>.
+            </p>
+
+          <p><strong>Avoid Heavy Functional Processing without Authentication</strong></p>
+            <p>
+              When defining WoT Interfaces exposed by a TD,
+              it is important to avoid any heavy functional processing 
+	      before the successful authentication of a WoT Consumer.
+              Any publicly exposed network interface should avoid heavy processing altogether. 
+            </p>
+            <p>
+             This recommendation helps prevent the following threats: 
+            <a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a>.
+            </p>
+
+         <p><strong>Minimize Network Interface Functionality and Complexity</strong></p>
+          <p>
+           Network interfaces exposed by a TD (WoT Interfaces) should only provide
+           the minimal necessary functionality, which helps to minimize implementation errors,
+           possibilities for exposing potentially sensitive data, DoS attack possibilities etc.
+           Devices should be strongly encapsulated, meaning the network interfaces should not
+           expose implementation details (for example, the use of particular software frameworks).
+          </p>
+          <p>
+           This recommendation helps prevent the following threats:
+            <a href="#dfn-wot-interface-threat-exposed-thing-compromise" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-exposed-thing-compromise-4">WoT Interface Threat - Exposed Thing Compromise</a>,
+            <a href="#dfn-wot-interface-threat-unauthorized-wot-interface-access" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-unauthorized-wot-interface-access-4">WoT Interface Threat - Unauthorized WoT Interface Access</a>,
+            <a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a>.
+          </p>
+
+         <p><strong>Strong Validation and Fuzz Testing on All WoT Interfaces</strong></p>
+          <p>
+           All WoT Interfaces (and especially public ones) 
+	   should be well-tested (including fuzz testing) and validated 
+	   since they are a primary attack surface of a WoT Thing. 
+          </p>
+          <p>
+           This recommendation helps prevent the following threats:
+            <a href="#dfn-wot-interface-threat-exposed-thing-compromise" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-exposed-thing-compromise-5">WoT Interface Threat - Exposed Thing Compromise</a>,
+            <a href="#dfn-wot-interface-threat-unauthorized-wot-interface-access" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-unauthorized-wot-interface-access-5">WoT Interface Threat - Unauthorized WoT Interface Access</a>,
+            <a href="#dfn-wot-dos-threat" class="internalDFN" data-link-type="dfn">WoT DoS Threat</a>.
+          </p>
+
+      </section>
+
+      
+
+      <section id="sec-pract-end-to-end-security">
+        <h3 id="x7-4-secure-practices-for-end-to-end-security"><bdi class="secno">7.4 </bdi>Secure Practices for End-to-End security<a class="self-link" aria-label="§" href="#sec-pract-end-to-end-security"></a></h3>
+            <p>
+              The notion 'end-to-end' security (short: E2E security) is often encountered when security 
+	      is considered. Quite often, this notion is encountered in a way that is misleading: it is a 
+	      matter of risk assessment to determine the "ends" that are to be protected in a distributed 
+	      system such as WoT (identifying the domain-of-protection) and then select one or more security 
+	      technologies to fulfill the identified demand (not: vice versa). 
+            </p>
+            <p>
+              In that sense, there is no single, universal notion of E2E security in WoT. There is also no 
+	      single security technology that allows to deliver E2E security for any definition of the ends. 
+	      The perception of WoT security is to support users of WoT in implementing security architectures 
+	      according their perception of the ends (which can vary across users, deployments etc.) using for 
+	      instance:
+	      </p><ul>
+                 <li>CMS as well as XML/JSON/CBOR security (IETF resp. <abbr title="World Wide Web Consortium">W3C</abbr>) to provide E2E security on the level 
+		     of application data</li>
+                 <li>(D)TLS (IETF) to provide E2E security between client and server processes</li>
+                 <li>IPsec (IETF) to provide E2E security between endpoints in an IP-based inter-network</li>
+		 <li>MACsec (IEEE) to provide E2E security between endpoints in one local network</li>
+              </ul>
+            <p></p>
+	    <p>
+              The following technologies allow to address E2E security in the first sense (protecting exchanges 
+	      between WoT system components on the level of application data):
+	      </p><ul>
+                 <li>If authenticity is desired for exchanged application data, then sign WoT objects (TDs, system 
+	             user data) using either digital signatures (using asymmetric cryptographic primitives) or Message 
+	             Authentication Codes (MACs, using symmetric cryptographic primitives). Such digital signatures or 
+		     MACs are created by the producers/issuers of the objects and validated by consumers of the objects 
+		     (which should reject signed the objects whose signatures/MACs are invalid). For data expressed in 
+		     JSON, [<cite><a class="bibref" data-link-type="biblio" href="#bib-jws15" title="JSON Web Signature (JWS)">JWS15</a></cite>] provides a guideline for expressing digital signatures or MACs as well as related 
+		     security metadata using JSON-based data structures. [<cite><a class="bibref" data-link-type="biblio" href="#bib-cose17" title="CBOR Object Signing and Encryption (COSE)">COSE17</a></cite>] does the same for CBOR.</li>
+                 <li>If confidentiality is desired for exchanged application data, then encrypt WoT objects using well-known 
+		     encryption primitives. For data expressed in JSON, [<cite><a class="bibref" data-link-type="biblio" href="#bib-jwe15" title="JSON Web Encryption (JWE)">JWE15</a></cite>] provides a guideline for expressing 
+	             encrypted data as well as related security metadata using JSON-based data structures. [[COSE17] does 
+	             the same for CBOR. Moreover the following is important here:
+		     <ul>
+                         <li>Confidentiality without authenticity (i.e. encryption-only) does not provide a secure scheme. 
+		             Use authenticated encryption, not encryption-only to provide confidentiality</li>
+                         <li>Classical cryptographic schemes (pre-AEAD, see [<cite><a class="bibref" data-link-type="biblio" href="#bib-aead08" title="An Interface and Algorithms for Authenticated Encryption">AEAD08</a></cite>]) cover encryption-only as well as 
+		             authentication-only. This requires users of cryptographic schemes to create an own design to 
+			     deliver authenticated encryption and this tends to go wrong. Use AEAD schemes to deliver 
+		             authenticated encryption (or use an underlying security protocol such as (D)TLS – when this can 
+			     fulfill the identified E2E security demand)</li>
+                      </ul>
+		 </li>
+              </ul>
+            <p></p>
+            <p>
+            This recommendation helps prevent the following threats: 
+            <a href="#dfn-wot-communication-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Authenticity</a>,
+            <a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a>,
+            <a href="#dfn-leaking-wot-system-user-data" class="internalDFN" data-link-type="dfn">Leaking WoT System User Data</a>,
+            <a href="#dfn-wot-communication-threat-td-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Authenticity</a>,
+            <a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a>.
+            </p>
+      </section>
+    </section>
+
+  
+
+    <section id="examples-of-wot-security-configurations">
+    <h2 id="x8-examples-of-wot-security-configurations"><bdi class="secno">8. </bdi>Examples of WoT Security Configurations<a class="self-link" aria-label="§" href="#examples-of-wot-security-configurations"></a></h2>
+        <p>
+          The WoT is intended to be used in variety of use cases and deployment configurations.
+          While the examples in this section do not cover all possible deployment variations, they cover
+          many common cases, shows how security mechanisms can be configured for these cases,
+          and highlights some details relevant to security.
+        </p>
+
+           <section id="wot-client-server-basic">
+           <h3 id="x8-1-basic-interaction-between-wot-thing-and-wot-consumer"><bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer<a class="self-link" aria-label="§" href="#wot-client-server-basic"></a></h3>
+            <p>
+              <a href="#wot_client_thing_basic" class="fig-ref" title="Basic WoT Thing and WoT Consumer">Figure <bdi class="figno">3</bdi></a> shows the basic WoT Consumer
+	      (which can be a browser or an application on a user's smartphone)
+              used to directly operate a WoT Thing.
+	      The WoT Thing exposes a WoT Interface and also directly provides
+              a Thing Description.
+              The Thing Description describes the interactions that can be performed on the WoT Thing.
+            </p>
+            <figure id="wot_client_thing_basic">
+              <img src="images/client-server-basic.png" style="width: 500px;" height="822" width="1726">
+              <figcaption>Figure <bdi class="figno">3</bdi> <span class="fig-title">Basic WoT Thing and WoT Consumer</span></figcaption>
+            </figure>
+            <p>
+            From a security point of view two aspects are important to consider in this scenario.
+            First, the WoT Consumer should be certain that it is talking to the correct WoT Thing 
+	    and not to some other device exposed on the same network.
+            Users intending to control a specific device, for example opening a garage door,
+            want to make sure they are talking to their own garage door device.
+            In security terms this means that WoT Consumer must have a way to
+            authenticate the device exposing the WoT Thing.
+            Second, upon receiving requests from a WoT Consumer,
+            the WoT Thing must verify the the WoT Consumer is authorized to perform such requests.
+            For example, a garage door must only process "open" requests from devices associated with 
+            authorized users or service providers and not from arbitrary passerby.
+            </p>
+            <p>
+            These requirements can both be fulfilled using a variety of different security mechanisms.
+            The choice of concrete security mechanisms depends on the deployment scenario,
+            as well as capabilities of the devices.
+            Either or both the WoT Consumer and the WoT Thing might have some resource,
+	    network connectivity, or user interface constraints that may limit the choice of security mechanisms.
+            </p>
+            <p>
+            For example, suppose the WoT Thing is actually an OCF device that has been provided with
+            a Thing Description.  This is a reasonable use case since WoT metadata can be used to describe
+            OCF devices, which have RESTful CoAP and/or HTTP network interfaces.  Since the WoT only
+	    describes devices during operational phase, and does not describe onboarding or provisioning
+	    processes, we have to refer to an external standard (such as OCF) that does specify these
+            processes.  However, it should be clear that much of what is described in this example is
+            applicable to other standards or even to custom solutions.
+            </p>
+            <p>
+	    The WoT Consumer and the OCF device providing the network interface acting as the WoT Thing can
+            use one of the following methods
+	    recommended by the OCF Security Specification [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>] (see Section 10) to mutually authenticate
+            each other given that there is a way to supply credential information required for authentication
+            during provisioning:
+            </p><ul>
+            <li><strong>Symmetric key credentials.</strong> 
+		    This method assumes that both WoT Consumer and the device exposing WoT Thing have pre-shared
+		    symmetric key credentials.
+		    Such keys can be established during device provisioning/on-boarding phase.
+		    In this case, since this is actually an OCF device,
+		    it can use one of the methods recommended in Section 7 [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>] 
+		    or can use an ad-hoc security protocol,
+		    such as EC Diffie-Hellmani, based on other existing pre-shared credentials.
+		    See Section 9.2.1 [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>] for more details on such credential types.</li>
+            <li><strong>Raw asymmetric public key credentials.</strong>
+		    This method assumes that a WoT Consumer has been provisioned with the public key
+		    of the device exposing the WoT Thing (and vice versa) 
+		    so the devices are able to mutually authenticate each other.
+		    Provisioning of public keys can take place during a device provisioning/on-boarding phase.
+		    In the case of OCF devices,
+		    this can take place using one of the methods recommended in Section 7 [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>].
+		    Section 9.2.3 [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>] also provides more details on this credential type as well as
+		    guidance on its secure provisioning.</li>
+            <li><strong>Certificates.</strong> This method assumes that the WoT Consumer has been provisioned
+		    with the certificate of the device exposing the WoT Thing (and visa versa) 
+		    so the devices are able to mutually authenticate each other.
+		    The provisioning of the certificates can take place during device provisioning/on-boarding phase
+		    using one of the methods recommended in Section 7 [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>].
+		    Section 9.2.5 [<cite><a class="bibref" data-link-type="biblio" href="#bib-ocf17" title="The OCF Security Specification, version 1.0.0">Ocf17</a></cite>] also provides more details on this 
+		    credential type as well as Section 9.3.</li>
+            </ul>
+            <p></p>
+            <p>
+            In case it is not possible to pre-provision any of the types of credentials described above
+	    during the network setup phase or if the WoT Thing wants to use a more fine-grained access control policy
+	    on the WoT Interfaces it is exposing 
+	    (for example, different controls might require different levels
+	    of authorization), the following methods can be used instead:
+            </p><ul>
+            <li><strong>OAuth 2.0-based access tokens.</strong> These tokens follow the JSON Web Token (JWT)
+		    format defined in RFC 7519 [<cite><a class="bibref" data-link-type="biblio" href="#bib-jwt15" title="JSON Web Token (JWT)">JWT15</a></cite>] and should used according to the suggestions by 
+		    the IETF Authentication and Authorization for Constrained Environments (ACE) 
+		    specification draft [<cite><a class="bibref" data-link-type="biblio" href="#bib-ietface" title="IETF Authentication and Authorization for Constrained Environments (ACE)">IETFACE</a></cite>].
+		    These are recommended for devices that are able to use the HTTP protocol and
+		    do not have significant resource constraints.</li>
+            <li><strong>Proof-of-possession (PoP) tokens.</strong> These are extensions of the OAuth 2.0-based 
+		    access tokens that follow the CBOR web token (CWT) format [<cite><a class="bibref" data-link-type="biblio" href="#bib-cbor17" title="CBOR Web Token (CWT)">CBOR17</a></cite>].
+		    The IETF Authentication and Authorization for Constrained Environments (ACE) 
+		    specification draft [<cite><a class="bibref" data-link-type="biblio" href="#bib-ietface" title="IETF Authentication and Authorization for Constrained Environments (ACE)">IETFACE</a></cite>]
+		    recommends such tokens for resource-constrained devices using the COAP protocol 
+		    instead of HTTP.
+		    For details of using such tokens please see [<cite><a class="bibref" data-link-type="biblio" href="#bib-ietface" title="IETF Authentication and Authorization for Constrained Environments (ACE)">IETFACE</a></cite>].</li>
+            </ul>
+            <p></p>
+            <p>
+            Instead of assigning different access tokens to different WoT Interfaces,
+            it is also possible to group related WoT Interfaces under some group or capability name
+            (i.e. "Light controls", "House access" etc.) 
+	    and assign one token per group to guard any such interfaces.
+            This can provide more balanced access control granularity in many circumstances.
+            </p>
+            <p>
+            Suitable choices of the above security measures allows mitigation of the 
+	    <a href="#dfn-wot-interface-threat-unauthorized-wot-interface-access" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-wot-interface-threat-unauthorized-wot-interface-access-6">WoT Interface Threat - Unauthorized WoT Interface Access</a> threat.
+            </p>
+            <p>
+            In addition to the above measures,
+	    authenticity, confidentiality and replay protection of transferred solution data and of 
+	    TDs between the WoT Consumer and the WoT Thing is strongly recommended for scenarios
+	    where an attacker can observe or/and modify the traffic in the WoT System.
+            While TD transfer might only require authenticity protection, 
+	    the solution data itself usually requires protection of all its aspects.
+            This helps to mitigate the following threats:
+            <a href="#dfn-wot-communication-threat-td-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Authenticity</a>, 
+	    <a href="#dfn-wot-communication-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - TD Confidentiality and Privacy</a>,
+            <a href="#dfn-wot-communication-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Authenticity</a>,
+            <a href="#dfn-wot-communication-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Communication Threat - System User Data Confidentiality and Privacy</a>.
+            </p>
+            <p>
+            Authenticity, confidentiality and replay protection can be guaranteed by usage of secure 
+	    transport protocols to exchange data between the WoT Consumer and the WoT Thing, such as TLS/DTLS.
+            If the underlying protocol does not provide the required security (such as plain CoAP run over
+	    a non-(D)TLS protected channel), then authenticity and confidentiality of the transferred data
+	    can be implemented separately on the application layer.
+	    The recommended method for doing this in resource constrained environments is to use the 
+	    Object Security of CoAP (OSCoAP) method described in the IETF Object Security of CoAP (OSCoAP)
+	    specification draft [<cite><a class="bibref" data-link-type="biblio" href="#bib-oscoap17" title="Object Security of CoAP (OSCOAP)">OSCOAP17</a></cite>].
+            </p>
+            <p>
+            The scenario shown in <a href="#wot_client_thing_basic_2" class="fig-ref" title="Basic WoT Thing and WoT Consumer with TD provided from a Thing Directory">Figure <bdi class="figno">4</bdi></a> is similar but with the important
+	    difference that a Thing description is not stored on the WoT Thing device nor returned by it directly.
+            The TD is instead provided to the WoT Consumer from a Thing Directory residing on some other
+	    system, such as a cloud server.  
+	    This mode may be useful for "retro-fitting" existing devices with Thing Descriptions, for example,
+	    or when more secure access to the TD is required than the device itself can support.
+            </p>
+            <figure id="wot_client_thing_basic_2">
+              <img src="images/client-server-basic-2.png" style="width: 500px;" height="1079" width="1727">
+              <figcaption>Figure <bdi class="figno">4</bdi> <span class="fig-title">Basic WoT Thing and WoT Consumer with TD provided from a Thing Directory</span></figcaption>
+            </figure>
+            <p>
+            The primary additional security consideration of this scenario is the need for the secure transfer
+            of the TD between the WoT Consumer and the Thing Directory.
+	    The Thing Directory can reside in a Intermediary WoT Servient but could also be supported by a service running
+	    on a remote cloud or other remote location.
+	    Similarly to the methods described above such transfer should be done using secure transport protocols.
+            In the case that the WoT Consumer is not resource constrained,
+            the usage of TLS/DTLS is the recommended method.
+            In case the remote cloud does not guarantee the secure storage and delivery of
+            Thing Descriptions to the WoT Consumer or in case the remote cloud is not a trusted entity,
+	    the authenticity of the Thing Description should be verified using other methods on the application layer,
+            such as wrapping the Thing Description into a protected 
+	    CBOR Object Encryption and Signing (COSE) object [<cite><a class="bibref" data-link-type="biblio" href="#bib-cose17" title="CBOR Object Signing and Encryption (COSE)">COSE17</a></cite>].
+            This can be done by the provider of the Thing Description and verified by the 
+	    WoT Consumer after the download from the remote cloud.
+            </p>
+          </section>
+          <section id="interaction-between-wot-thing-and-wot-consumer-via-an-intermediary-wot-servient">
+          <h3 id="x8-2-interaction-between-wot-thing-and-wot-consumer-via-an-intermediary-wot-servient"><bdi class="secno">8.2 </bdi>Interaction between WoT Thing and WoT Consumer via an Intermediary WoT Servient<a class="self-link" aria-label="§" href="#interaction-between-wot-thing-and-wot-consumer-via-an-intermediary-wot-servient"></a></h3>
+            <p>
+            A <a href="#wot_client_thing_gateway" class="fig-ref" title="WoT Thing and WoT Consumer via Intermediary WoT Servient">Figure <bdi class="figno">5</bdi></a>, 
+	    as in the <a href="#wot_client_thing_basic" class="fig-ref" title="Basic WoT Thing and WoT Consumer">Figure <bdi class="figno">3</bdi></a> configuration,
+            also allows a WoT Consumer to connect to and operate or monitor a WoT Thing.
+            However in contrast to the basic (direct connection) case,
+            the interaction between the WoT Consumer and the WoT Thing is now mediated by an Intermediary WoT Servient.
+            The Intermediary WoT Servient exposes a WoT interface and provides a Thing Description that describes 
+            interactions that that apply to the Thing.
+            In general, the TD provided by the Intermediary WoT Servient is structurally
+            identical to the one that would have been provided by the Thing directly,
+            except for any necessary modifications to URLs, protocols used,
+	    and (perhaps) a modified security configuration.
+            </p>
+            <figure id="wot_client_thing_gateway">
+              <img src="images/client-server-gateway.png" style="width: 1000px;" height="763" width="2667">
+              <figcaption>Figure <bdi class="figno">5</bdi> <span class="fig-title">WoT Thing and WoT Consumer via Intermediary WoT Servient</span></figcaption>
+            </figure>
+            <p>
+            From a security standpoint this case is quite similar to the one described in 
+	    Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>. 
+            The main difference is that mutual authentication should be established between 
+	    all directly communicating parties,
+            i.e. between the WoT Consumer and the Intermediary WoT Servient,
+            as well as between the Intermediary WoT Servient and the device exposing the WoT Thing network interface.
+            If there is no direct communication between the Intermediary WoT Servient
+            and the device providing the WoT Thing however the mutual authentication between them is redundant.
+            The authentication mechanisms described in Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>
+            are also applicable for this case.
+            </p>
+            <p>
+            The Thing Description that the Intermediary WoT Servient device provides to the WoT Consumer 
+            can be the same as it gets from the device exposing the WoT Thing or it can be modified 
+            to better suit the deployment use case or expose additional functionality via the Intermediary WoT Servient.
+            It is also possible that the end device behind the Intermediary WoT Servient is a non-WoT Device and does
+            not provide any Thing Description on its own, 
+	    and may not support any interaction via a WoT-compatible network Interface.
+            In this case the Intermediary WoT Servient has to build the Thing Description by itself i
+	    and expose it to the WoT Consumer.
+            For all typical use cases,
+            the Intermediary WoT Servient should be considered a trusted entity and in this case
+            it can freely modify or build Thing Descriptions it exposes as well as set up 
+            fine-grained access controls on different exposed WoT Interfaces.
+            The Intermediary WoT Servient can do this using the same methods described in
+            Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>, i
+	    and therefore acts fully on behalf of the end device.
+            </p>
+            <p>
+            <a href="#wot_client_thing_gateway_2" class="fig-ref" title="WoT Thing and WoT Consumer via Intermediary WoT Servient with Remote Cloud">Figure <bdi class="figno">6</bdi></a> is similar to the previous case 
+	    but with an important difference:
+            a Thing Description is not provided by the the Intermediary WoT Servient,
+            but can be fetched by the WoT Consumer from a Thing Directory residing on a remote system.
+            Similar to the previous case,
+            this Thing Description can either be the original Thing Description supplied by the end device
+            or modified by the Intermediary WoT Servient.
+            Regardless of the actual setup,
+            the transfer of a Thing Description between any two endpoints should be done 
+	    using underlying secure protocols.
+            Currently the use of TLS or DTLS is recommended.
+            Similarly to Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>, 
+	    in case the remote system does not guarantee
+            the secure storage and delivery of Thing Descriptions to the WoT Consumer
+            or in case the remote system is not a trusted entity,
+            the authenticity of the Thing Description should be verified 
+	    using other methods in the application layer.
+            </p>
+            <figure id="wot_client_thing_gateway_2">
+              <img src="images/client-server-gateway-2.png" style="width: 1000px;" height="1090" width="2668">
+              <figcaption>Figure <bdi class="figno">6</bdi> <span class="fig-title">WoT Thing and WoT Consumer via Intermediary WoT Servient with Remote Cloud</span></figcaption>
+            </figure>
+          </section>
+
+          <section id="wot-client-server-double-proxy">
+           <h3 id="x8-3-basic-interaction-between-wot-thing-and-wot-consumer-via-a-split-proxy"><bdi class="secno">8.3 </bdi>Basic Interaction between WoT Thing and WoT Consumer via a Split Proxy<a class="self-link" aria-label="§" href="#wot-client-server-double-proxy"></a></h3>
+
+           <p>
+            <a href="#wot_client_thing_double_proxy" class="fig-ref" title="WoT Thing and WoT Consumer via Split Proxy">Figure <bdi class="figno">7</bdi></a> shows another common situation
+            where the WoT Thing resides in a local protected network, e.g. behind a NAT/Firewall.
+            In this case the WoT Consumer cannot contact the WoT Thing directly.
+            In the configuration shown here the communication between the WoT Consumer and the WoT Thing 
+            is handled via a pair of Intermediary WoT Servients: 
+            one residing in the local protected network, known as the Local Intermediary WoT Servient,
+            and another running in the cloud, known as the Remote Intermediary WoT Servient.
+            We refer to this configuration as a "Split Proxy" because the 
+	    combination of the Local and Remote Proxy together
+            act like a single proxy service.
+            The Local and Remote Intermediary WoT Servients are connected with a secure channel 
+	    (which may be non-WoT, eg it does not have to use a protocol known to WoT) 
+	    as the Local Intermediary WoT Servient only communicates over this channel with the Remote Intermediary WoT Servient.
+            The WoT Remote Intermediary WoT Servient should use the mechanisms described in 
+	    Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>
+            in order to authenticate and authorize the WoT Consumer before processing any of its requests.
+            Similar to the configurations described in Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>,
+            secure protocols should be used to protect authenticity and confidentiality 
+	    and provide replay protection when
+            data is exchanged between the WoT Consumer and the Remote Intermediary WoT Servient.
+            If the WoT Consumer is authorized,
+            then the Remote Intermediary WoT Servient can package the WoT request 
+	    and transfer it over the secure channel to the Local Intermediary WoT Servient,
+            which in turn can issue requests to the WoT Thing on the local network.
+            The local network channel between the Local Intermediary WoT Servient and the WoT Thing can be left unprotected
+            (relying purely on the closed nature of the local network),
+            but it is strongly recommended to employ suitable additional security mechanisms 
+            as described in Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a> to perform authentication
+            and authorization of involved parties (WoT Thing and Local Intermediary WoT Servient),
+            as well as to provide confidentiality and integrity of transferred solution data and the TD.
+           </p>
+
+            <figure id="wot_client_thing_double_proxy">
+              <img src="images/client-server-double-proxy.png" style="width: 1000px;" height="1071" width="2704">
+              <figcaption>Figure <bdi class="figno">7</bdi> <span class="fig-title">WoT Thing and WoT Consumer via Split Proxy</span></figcaption>
+            </figure>
+
+           <p>
+            An alternative security setup for this scenario can use end-to-end security 
+	    authentication and authorization.
+            In this case the WoT Consumer would not only need to authenticate and authorize 
+	    itself to the Remote Intermediary WoT Servient,
+            but also to the WoT Thing.
+            In this case it would need a separate set of security credentials,
+            required to successfully authenticate with each party.
+	    The exposed TD should indicate the mechanisms to obtain these credentials, e.g. via OAuth2.          
+          </p>
+
+          </section>
+
+          <section id="wot-client-server-tunnel">
+           <h3 id="x8-4-basic-interaction-between-wot-thing-and-wot-consumer-via-a-tunnel"><bdi class="secno">8.4 </bdi>Basic Interaction between WoT Thing and WoT Consumer via a Tunnel<a class="self-link" aria-label="§" href="#wot-client-server-tunnel"></a></h3>
+
+           <p>As an alternative to the use of a split proxy, 
+	   which requires a trusted remote proxy to accept interaction
+           requests on behalf of the WoT Thing, 
+	   a secure tunnel (such as an SSH tunnel) can be set up between the WoT Thing and
+           an endpoint in the cloud.  
+	   In order to traverse the NAT the WoT Thing would have to initiate the connection, so
+           in practice this would be a reverse tunnel set up by the "server". 
+	   However, then a port made available by the Thing would be made
+           available directly on the cloud server supporting the tunnel endpoint, 
+	   possibly mapped to a different port.
+	   The use of a tunnel for NAT traversal is shown in <a href="#wot_client_thing_tunnel" class="fig-ref" title="WoT Thing and WoT Consumer via Tunnel">Figure <bdi class="figno">8</bdi></a>.
+           </p>
+           <figure id="wot_client_thing_tunnel">
+              <img src="images/tunnel.png" style="width: 1000px;" height="1071" width="2677">
+              <figcaption>Figure <bdi class="figno">8</bdi> <span class="fig-title">WoT Thing and WoT Consumer via Tunnel</span></figcaption>
+            </figure>
+		  
+           <p>
+           In this configuration the WoT Thing must be responsible for all security, 
+	   including (if necessary) certificates
+           appropriate for the tunnel endpoint in the cloud.  i
+	   This implies that the WoT Thing needs to be relatively powerful, 
+	   as constrained devices may not be able to support security mechanisms suitable for
+           direct exposure on the Internet.  
+	   The WoT Thing would also have to be actively maintained and patched.
+           If the WoT Thing provides a TD, it should use URLs that refer to the tunnel endpoint.  
+	   This generally means that the port used for the local side of the tunnel
+           should not be used to provide local connections as the certificates will be 
+	   incorrect for local connections.
+           Instead a separate port (and possibly a separate TD with local URLs) should be provided.
+           </p>	  
+           <p>One advantage of this arrangement is that communication is never available in plaintext on either the
+           gateway or the client.  Specifically, the private keys for end-to-end communication between the 
+	   WoT Thing and the WoT Consumer, assuming a secure protocol stack such as HTTP-over-TLS is used, never need to be made
+	   available to either the local gateway or to the cloud portal.
+           In other words, this configuration supports end-to-end encrypted communication, and does not rely
+           on trusting either the gateway or the cloud portal.
+           Because of this, it is not technically necessary for the tunnel to be over SSH; 
+	   a regular IP tunnel would suffice.
+	   </p>
+	   <p>A variation of this is shown in <a href="#wot_client_thing_proxy" class="fig-ref" title="WoT Thing and WoT Consumer via HTTP-over-TLS ( HTTPS)/HTTP Proxy">Figure <bdi class="figno">9</bdi></a>.  
+	   A reverse tunnel is still
+           used here, but terminates in a local port "inside" the cloud portal, 
+	   that is, the local port is not made visible outside
+	   the cloud portal's firewall.  
+	   A local proxy service then runs inside the cloud portal and provides
+	   a bridge to a secure external network interface.  
+	   For example, the protocol from the WoT Thing might be HTTP,
+           which the proxy service could bridge to an external HTTP-over-TLS (HTTPS) network interface.  
+	   In this case, the
+           tunnel should be encrypted (for example, using SSH) to prevent eavesdropping; 
+	   a regular IP tunnel is not sufficient.
+           Depending on the configuration, 
+           the unencrypted traffic (eg HTTP) may also be visible on the local network.   
+	   In this case, the only protection
+           would be from that provided by the local network, eg WPA.
+           If such a relatively unprotected local interface is <em>not</em> desirable,
+	   another SSH tunnel can be used between the WoT Thing and the Intermediary WoT Servient, 
+	   or the WoT Thing can act as
+           its own gateway (with the HTTP traffic protected behind a firewall).
+           </p>
+	   <p>To support local SSH tunnels, of course credentials need to be provisioned between the gateway and the
+	   cloud portal.  However, this only needs to be done once, when the gateway is installed.
+	   </p>
+           <p>It is worth emphasizing that the security in this configuration is weaker than in the end-to-end
+           tunnel configuration.  In particular, unencrypted traffic is available both locally (on the local network
+           and/or inside the gateway) and in the cloud portal.  Therefore both the gateway and the cloud portal
+           need to be trusted.  This can be mitigated somewhat by using application-level end-to-end object security
+           [<cite><a class="bibref" data-link-type="biblio" href="#bib-cose17" title="CBOR Object Signing and Encryption (COSE)">COSE17</a></cite>].
+           </p>
+		  
+            <figure id="wot_client_thing_proxy">
+              <img src="images/proxy.png" style="width: 1000px;" height="1071" width="2674">
+              <figcaption>Figure <bdi class="figno">9</bdi> <span class="fig-title">WoT Thing and WoT Consumer via HTTP-over-TLS (
+HTTPS)/HTTP Proxy</span></figcaption>
+            </figure>
+
+           <p>Yet another variant of this approach is shown in <a href="#wot_client_thing_proxy" class="fig-ref" title="WoT Thing and WoT Consumer via HTTP-over-TLS ( HTTPS)/HTTP Proxy">Figure <bdi class="figno">9</bdi></a>.
+	   In this variant, the proxy is extended to support caching.
+           This means that the proxy may not always forward requests to the 
+           WoT Thing, but may instead respond on its behalf using stored state.
+           </p>
+           <p>There are two sub-variants of this approach.
+           First, a simple HTTP Proxy can be used that caches responses from the WoT Thing.
+           For example, property reads might return an exact copy of an earlier cached payload if only a small
+           amount of time (for some configurable value of "small") 
+	   has elapsed since the last request for that property.
+           However, this approach still requires that the WoT Thing be "always on"
+           and able to respond as a server in case cached content is not available or has expired.
+           It also requires some care on the part of the WoT Thing to mark payloads as cacheable
+           or uncacheable and configure appropriate time-to-live values.
+           </p>
+            <figure id="wot_client_thing_cachingproxy">
+              <img src="images/cachingproxy.png" style="width: 1000px;" height="1071" width="2674">
+              <figcaption>Figure <bdi class="figno">10</bdi> <span class="fig-title">WoT Thing and WoT Consumer via HTTP-over-TLS (HTTPS)/HTTP Proxy</span></figcaption>
+            </figure>
+            <p>The second sub-variant, shown in <a href="#wot_client_thing_cachingproxy" class="fig-ref" title="WoT Thing and WoT Consumer via HTTP-over-TLS (HTTPS)/HTTP Proxy">Figure <bdi class="figno">10</bdi></a>,
+           takes advantage of the metadata provided by the Thing Description.
+           Specifically, the Thing Description indicates which interactions are "properties" that can be "observed".
+           The proxy service can "observe" all such properties and maintain copies of their state in the cloud server
+           (it is also possible to do this in the gateway, a sub-variant of this pattern).
+           Then when a request comes in to read a property, it can be read from the stored state.  However, the 
+           "observe" pattern allows the WoT Thing to send updates on its own schedule, leading to greater power
+	   efficiency.  In addition, the proxy service can see from the Thing Description which network interface
+           methods are "actions" and need to be sent directly to the WoT Thing.  This reduces the need for the 
+           WoT Thing to mark interactions as being cacheable or not.
+		    
+           </p>
+           <p>In both of these sub-patterns, object security (that is, encryption and authentication of payloads
+	   at the application level) can be used to preserve confidentiality and integrity if necessary [<cite><a class="bibref" data-link-type="biblio" href="#bib-cose17" title="CBOR Object Signing and Encryption (COSE)">COSE17</a></cite>].
+	   A caching proxy can
+	   simply store and return copies of the encrypted data representing the state of "private" properties.
+           </p>
+           <p>A caching proxy, being a variant of the proxy configuration discussed above,
+           has similar security caveats.
+           </p>
+         </section>
+
+         <section id="wot-servient-single-tenant">
+           <h3 id="x8-5-wot-servient-single-tenant"><bdi class="secno">8.5 </bdi>WoT Servient Single-Tenant<a class="self-link" aria-label="§" href="#wot-servient-single-tenant"></a></h3>
+           <p>
+           In previous examples we have considered the Wot Servient as a black box 
+	   exposing a set of WoT Interfaces and Thing Descriptions. 
+	   <a href="#wot_servient-single-tenant" class="fig-ref" title="WoT Servient Single-Tenant">Figure <bdi class="figno">11</bdi></a> shows the WoT Servient 
+	   (for example consider again a garage door controller device or an Intermediary WoT Servient) 
+	   in more detail with Scripting API support and a couple of scripts running inside a WoT runtime. 
+	   For this case we consider all scripts to be trusted and provisioned 
+	   to the device by a single trusted entity (for example by the manufacturer during factory installation).
+            </p>
+            <figure id="wot_servient-single-tenant">
+              <img src="images/servient-single-tenant.png" style="width: 500px;" height="933" width="1579">
+              <figcaption>Figure <bdi class="figno">11</bdi> <span class="fig-title">WoT Servient Single-Tenant</span></figcaption>
+            </figure>
+            <p>
+            Since all scripts running inside the WoT runtime are considered trusted for this scenario, 
+	    there is no strong need to perform strict isolation between each running script instance. 
+	    However, depending on device capabilities and deployment use case scenario risk level 
+	    it might be desirable to do so. 
+	    For example, if one script handles sensitive privacy-related data and well-audited, 
+	    it might be desirable to separate it from the rest of the script instances to minimize the 
+	    risk of data exposure in case some other script inside WoT gets compromised during the runtime. 
+	    Such isolation can be performed within the WoT Runtime 
+	    using platform security mechanisms available on the device.
+            </p>
+            <p>
+            Depending on the device capabilities, the following isolation mechanisms might be available:
+            </p><ul>
+            <li><strong>WoT Runtime enforced isolation.</strong> 
+	    This is the basic isolation provided by the WoT Runtime itself 
+	    and is based on restricting the API exposed to the scripts running within the WoT Runtime. 
+	    The exact set of guarantees depends on the concrete WoT Runtime implementation and might vary.</li>
+            <li><strong>Native OS process-based isolation.</strong> 
+	    This method relies on the underlying native OS to provide basic isolation guarantees 
+	    based on native process isolation. 
+	    The exact set of guarantees depends on capabilities of native OS, 
+	    but it usually includes at least memory and execution content isolation. 
+	    Some other mechanisms like Discretionary Access Controls (DAC) might be also available. </li>
+            <li><strong>Native OS advanced isolation.</strong> 
+	    An OS might also provide a stronger set of measures that can be deployed for process-based isolation. 
+	    Examples of such measures are Mandatory access Control (MACs in all major OSes), 
+	    OS-level virtualization (i.e. namespaces and containers in Linux), Cryptographic methods etc. </li>
+            </ul>
+            <p></p>
+            <p>
+            The mechanisms are provided in the order from weakest to the strongest isolation method 
+	    and can be used in combination. 
+	    In order to choose the appropriate mechanism one should study the capabilities of the underlying device, 
+	    as well as evaluate the risk level of particular deployment scenario. 
+	    
+	    It is also important to note that all isolation mechanisms usually affect performance 
+	    and might require non-trivial policy setup and management.
+            </p>
+            <p>
+            Now if we consider the basic communication scenario between the WoT Consumer 
+	    and the device exposing the WoT Thing described in Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a> 
+	    from a perspective of script instances running inside WoT Runtime, 
+	    each such instance should be able to have a way to perform mutual authentication 
+	    between itself and a remote WoT Consumer or support a token-based authentication method. 
+	    However, there are no methods in the WoT Scripting API to perform any such tasks.
+	    Instead the underlying WoT Runtime and protocol bindings handle the required 
+	    security functionality transparently for the WoT scripts. 
+	    <a href="#wot_scripts_security_1" class="fig-ref" title="Transparent handling of security during WoT Thing discovery and use">Figure <bdi class="figno">12</bdi></a> shows how it is done, 
+	    when a WoT Script discovers a new WoT Thing, MyLampThing, 
+	    using the discover() scripting API method, and invokes an action "toggle". 
+
+            </p><figure id="wot_scripts_security_1">
+              <img src="images/scripts-security-1.png" style="width: 1000px;" height="862" width="1845">
+              <figcaption>Figure <bdi class="figno">12</bdi> <span class="fig-title">Transparent handling of security during WoT Thing discovery and use</span></figcaption>
+            </figure>
+
+            <p></p>
+
+            <p>
+            <a href="#wot_scripts_security_2" class="fig-ref" title="Transparent handling of security during WoT Thing exposure">Figure <bdi class="figno">13</bdi></a> shows handling of security configuration 
+	    during the exposure of a new WoT Thing, MyLampThing. 
+	    Since the security configurations 
+	    (types of authentication and authorization methods and corresponding credentials) 
+	    are not exposed to the WoT Scripts, 
+	    but handled by the WoT Runtime and underlying protocol bindings, 
+	    WoT Scripts must either rely on the WoT Runtime to use the default credentials provisioned to it, 
+	    or indicate the choice of security methods and credentials 
+	    using a name/id tag known to the WoT Runtime.   
+
+
+            </p><figure id="wot_scripts_security_2">
+              <img src="images/scripts-security-2.png" style="width: 1000px;" height="917" width="2045">
+              <figcaption>Figure <bdi class="figno">13</bdi> <span class="fig-title">Transparent handling of security during WoT Thing exposure</span></figcaption>
+            </figure>
+
+            <p></p>
+            
+            </section>
+
+            <section id="wot-servient-multi-tenant">
+            <h3 id="x8-6-wot-servient-multi-tenant"><bdi class="secno">8.6 </bdi>WoT Servient Multi-Tenant<a class="self-link" aria-label="§" href="#wot-servient-multi-tenant"></a></h3>
+            <p>
+              <a href="#wot_servient-multi-tenant" class="fig-ref" title="WoT Servient Multi-Tenant">Figure <bdi class="figno">14</bdi></a> shows the WoT Servient 
+	      with two different tenants running in two different instances of WoT Runtime. 
+	      There is a no trust relation between different tenants and they can be untrusted. 
+	      Each tenant can have multiple independent WoT scripts running inside their WoT Runtime. 
+	      WoT Runtime core also has a Thing Manager entity that allows installation of scripts 
+	      into the corresponding WoT Runtimes.
+            </p>
+            <figure id="wot_servient-multi-tenant">
+              <img src="images/servient-multi-tenant.png" style="width: 600px;" height="1078" width="2234">
+              <figcaption>Figure <bdi class="figno">14</bdi> <span class="fig-title">WoT Servient Multi-Tenant</span></figcaption>
+            </figure>
+            <p>
+            The case of the multi-tenant servient with a possibility to install WoT Scripts remotely 
+	    into WoT Runtimes brings an additional set of threats that must be taken into account: 
+	    <a href="#dfn-wot-script-management-interface-threat" class="internalDFN" data-link-type="dfn">WoT Script Management Interface Threat</a>, 
+	    <a href="#dfn-wot-untrusted-script-threat-script-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Script Compromise</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-runtime-compromise" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Runtime Compromise</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-authenticity" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Authenticity</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-confidentiality" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - Confidentiality</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-td-authenticity" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - TD Authenticity</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-td-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - TD Confidentiality and Privacy</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-system-user-data-authenticity" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - System User Data Authenticity</a>,
+	    <a href="#dfn-wot-untrusted-script-threat-system-user-data-confidentiality-and-privacy" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - System User Data Confidentiality and Privacy</a>,
+	    and
+	    <a href="#dfn-wot-untrusted-script-threat-dos" class="internalDFN" data-link-type="dfn">WoT Untrusted Script Threat - DoS</a>.
+            </p>
+            <p>
+            In order to address these threats one should utilize the strongest isolation method available 
+	    on the device to separate different WoT Runtimes. 
+	    The isolation should cover execution context, 
+	    runtime memory, local storage and resource allocation between different WoT Runtimes.
+            </p>
+            <p>
+            In addition the Thing Manager should have a reliable way to distinguish 
+	    between different tenants in order to securely manage provisioning and updates of scripts 
+	    into the corresponding WoT Runtime. 
+	    This can be achieved by authenticating the tenant 
+	    using one of the authentication methods described in Section <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a>.
+            </p>
+            <p>
+            Also each tenant inside the WoT runtime requires a different set of security credentials 
+	    to be provisioned and made accessible for its scripts. 
+	    These credentials should be also strictly isolated between different tenants.
+            </p>
+            </section>
+    </section>
+
+    <section id="security-validation">
+      <h2 id="e-security-validation"><bdi class="secno">9. </bdi>Security Validation<a class="self-link" aria-label="§" href="#e-security-validation"></a></h2>
+          <p>This section provides guidance on how a WoT System implementation can be
+          tested in order to evaluate its security and privacy.  
+          A <a href="https://github.com/w3c/wot-security-best-practices/">WoT Security Best Practices</a> 
+          document describes best practices for securing WoT implementations.  
+          This section focuses on systems that follow those best practice since systems that do
+          not generally will have known vulnerabilities and testing
+          to reveal them would be redundant.
+          </p>WoT Systems can consist both of purpose-built components and pre-existing
+          components.  
+          Purpose-built WoT components should be
+          implemented using WoT security best practices.  
+          However, pre-existing systems may also have WoT Thing Descriptions written 
+          for them so that other WoT components can interface with them.  
+          Such "retrofitted" pre-existing components
+          may also have pre-existing security weaknesses and vulnerabilities.  
+          Security testing may reveal these
+          as well, but it should be understood that describing a network interface
+          using a WoT Thing Description does not guarantee that it will be secure: in order
+          to accommodate pre-existing devices, WoT Thing Descriptions need to be flexible
+          enough to describe both secure <em>and</em> insecure interfaces.
+          Security mitigations need to consider the entire system and should in
+          particular take into account that not all components of the system may be
+          equally secure.
+          <p></p>
+      <section id="testing-goals">
+      <h3 id="x9-1-testing-goals"><bdi class="secno">9.1 </bdi>Testing Goals<a class="self-link" aria-label="§" href="#testing-goals"></a></h3>
+          <p>
+          The goal of WoT security testing is to find security vulnerabilities in
+          the implementation of WoT components, so they can be mitigated.  
+          This can be broadened to finding weaknesses (potential vulnerabilities)
+          since mitigating both actual and potential vulnerabilities is
+          sufficient to secure a system, and in general it can be hard to determine
+          if a weakness is exploitable.
+          It is not possible in general to prove the converse, 
+          that a WoT component is secure (that is, that it has no vulnerabilities).  
+          However, thorough security testing can at least ensure
+          that there are no obvious (easily discoverable) weaknesses or 
+          vulnerabilities in an implementation.
+          </p><p>
+          Furthermore, the goal of security testing for an implementor is to identify the existence of
+          weaknesses, not to exploit them to break into or manipulate a system.
+          For an implementor, the priority after discovery of a weakness is to 
+          implement a mitigation to prevent it from being exploited,
+          not to actually find or create an exploit and use it.  
+          Not all weaknesses are vulnerabilities.  
+          Fixing actual (exploitable) vulnerabilities should have a higher priority than
+          simple weaknesses,
+          so an implementor may want to also determine which weaknesses are
+          exploitable in order to prioritize mitigations.
+          </p><p>
+          In the following we provide some background on testing, including
+          a description of several varieties of security testing and examples of suitable
+          tools for each.
+          While we provide some tool examples in the following,
+          they are just examples; you are free to use any tool that fits the purpose.
+          After introducing the categories of testing and examples of tools for each,
+          we then present a general security testing plan for WoT Systems based on these categories.
+          </p>
+    </section>
+    <section id="best-practices">
+      <h3 id="x9-2-best-practices"><bdi class="secno">9.2 </bdi>Best Practices<a class="self-link" aria-label="§" href="#best-practices"></a></h3>
+      <p>Before beginning security testing, it is useful to determine if the components 
+      of the system being tested have been implemented following good and up-to-date security practices.
+      What we really want to do is identify systems that use known insecure practices, 
+      for which vulnerabilities are known. Many times such vulnerabilities will be
+      obvious from the WoT Thing Description, and can be identified with simple tools.
+      </p><p>
+      As an example, suppose a WoT Thing combines "basic" authentication with plain (unencrypted) HTTP.
+      In this case the username and password can be easily recovered from the header
+      information of the unencrypted HTTP request by an eavesdropper with access to the 
+      network traffic, for example by code running in a compromised router or by someone
+      who has broken WiFi encryption.
+      </p><p>
+      As another example, an older device may use an obsolete form of encryption for which
+      an attack is known.
+      </p><p>
+      Hiding the Thing Descriptions of such systems is not really a solution: this is
+      equivalent to security by obscurity which is widely considered to be ineffective.
+      Generally, the "secret information" 
+      allowing access to a system should be in the form of easily modifiable keys,
+      not engineering details which, once revealed, cannot be easily changed.
+      However, certainly mitigating obvious vulnerabilities
+      easily discoverable in the Thing Description should be a high priority.
+      Ideally mitigation is accomplished by modifying the implementation but this
+      is not possible in all cases. If the implementation cannot be modified it may be
+      possible to achieve partial mitigation by securing the network environment, e.g. by
+      using a VPN or encrypted tunnels to encapsulate the vulnerable network traffic.
+      </p><p>
+      Another point to note is that a Thing Description may not describe all the
+      network interfaces of a Thing. A Thing may have a Thing Description that describes
+      a network interface that follows best practices and may pass all the additional
+      security tests described below on that interface, but may still have an insecure
+      backdoor (additional network interface) not described in the Thing Description.  
+      It is the implementor's
+      responsibility to secure <em>all</em> network interfaces, even if the Thing Description is
+      subsetted.  Note that there are valid reasons to subset a Thing Description,
+      for example to provide different interfaces to users with different roles and
+      access rights.
+      </p><p>
+      A WoT System may also have infrastructure components that do not have Thing Descriptions.
+      There may, for example, be services such as proxies or directories.  These
+      should also be tested.  If they are web services or otherwise have documented
+      network interfaces, then much of the testing
+      procedure described below should also apply to them.
+      </p><p>
+    </p></section>
+    <section id="functional-security-testing">
+      <h3 id="x9-3-functional-security-testing"><bdi class="secno">9.3 </bdi>Functional Security Testing<a class="self-link" aria-label="§" href="#functional-security-testing"></a></h3>
+      <p>Functional testing checks that a WoT Thing implements the interactions
+      described in its Thing Description. This includes whether or not it 
+      responds to all URLs given and accepts and returns data as specified 
+      in the data schemas given in the Thing Description for each interaction.
+      </p><p>
+      Functional testing should also check that all security mechanisms 
+      described in the Thing Description are implemented properly.
+      Does the Thing do what the Thing Description says it does in terms of security, 
+      and only that?
+      Does the Thing Description accurately describe the security mechanisms
+      used by the Thing?
+      Do all interactions accept authorized accesses, and reject accesses
+      that do not provide correct authentication and authorization information?
+      </p><p>
+      Again, there can be both purpose-built and pre-existing devices described 
+      by a Thing Description.  A Thing Description needs to accurately describe
+      the security behavior and requirements in both cases. 
+      </p>
+    </section>
+    <section id="adversarial-security-testing">
+      <h3 id="x9-4-adversarial-security-testing"><bdi class="secno">9.4 </bdi>Adversarial Security Testing<a class="self-link" aria-label="§" href="#adversarial-security-testing"></a></h3>
+      <p>Adversarial security testing (also known as penetration testing or pentesting) 
+      includes various checks that can be done in order
+      to find weaknesses in the target device or service and determine their
+      severity and exploitability (that is, whether they are actual vulnerabilities).
+      On a high level adversarial testing consists of three stages, which
+      are often applied iteratively:
+      </p><ol>
+          <li><strong>Information gathering:</strong> 
+          Required information is collected about the attack target.
+          </li><li><strong>Weakness discovery:</strong>
+          An attack target is analyzed and weaknesses are found.
+          </li><li><strong>Exploitation generation:</strong> 
+          An attempt is made to convert weaknesses into vulnerabilities
+          by discovering or designing exploits.
+      </li></ol>
+      <p>Exploits are designed to achieve a desired outcome, 
+      such as privilege escalation, authorization bypass, denial of service, and other goals.
+      A successful exploit of one vulnerability 
+      may be used to expose other weaknesses and allow them in turn to be exploitable.
+      Conversely, a weakness may be prevented from exploitation by a mitigation that
+      prevents the class of exploit to which it is vulnerable.
+      </p>
+      <p>Many resources and tools exist to help penetration and security testers to
+      perform the above activities.  Many documents and tutorials have also been written
+      to help guide this activity. One example of such guide is the "Web Service
+      Security Testing Cheat Sheet" [<cite><a class="bibref" data-link-type="biblio" href="#bib-owa18" title="Web Service Security Testing">Owa18</a></cite>] written by the Open Web Application
+      Security Project (OWASP).  Generally speaking, WoT components can be treated
+      as web services for the purposes of security testing, especially if they use HTTP.  
+      However, WoT components also
+      have some additional considerations, 
+      for example local access while using HTTP-over-TLS (HTTPS), or
+      use of non-HTTP protocols such as CoAP or MQTT.
+      </p><p>
+      For the purposes of WoT security testing we will focus on Stage 2,
+      <em>Weakness Discovery</em>.  
+      Weakness discovery can be broken down into a combination of
+      static weakness discovery and runtime weakness discovery.
+      </p><p>
+      Stage 1 is not really necessary in the case of white-box
+      testing, which we will assume (given that, for example, a Thing Description already
+      documents much of the information needed). Generally speaking, trying to achieve
+      security through obscurity is not feasible or desirable, so for testing we should assume the
+      attacker knows as much about the system as the implementor.
+      Also, since our goal is to test the 
+      security of the components of a WoT System, not actually break into it,
+      we also will not focus on Stage 3.
+      However, an exploitable vulnerability has a higher priority for correction 
+      than a simple weakness for which no exploit is (yet) known, so this information
+      is still useful to prioritize mitigation.
+      </p>
+      
+    <section id="static-weakness-discovery">
+    <h4 id="x9-4-1-static-weakness-discovery"><bdi class="secno">9.4.1 </bdi>Static Weakness Discovery<a class="self-link" aria-label="§" href="#static-weakness-discovery"></a></h4>
+      <p>Static weakness discovery typically requires an access to the target's source code,
+      and therefore is not always possible to perform for a black-box penetration tester.
+      However, since a WoT Thing developer or WoT Service provider have the access,
+      they are strongly encouraged to use the below methods to check for weaknesses (potential
+      vulnerabilities) in their components as part of white-box testing. 
+      Static weakness discovery is very well supported and automated.
+      Many tools are available, so after an initial setup phase,
+      it should add little overhead to the WoT component development and release process.
+      </p>
+
+      <section id="static-code-analysis">
+      <h5 id="x9-4-1-1-static-code-analysis"><bdi class="secno">9.4.1.1 </bdi>Static Code Analysis<a class="self-link" aria-label="§" href="#static-code-analysis"></a></h5>
+      <p>The most common example of static weakness discovery is usage of a
+      static code analyzer tool that is able to parse a program's code and
+      highlight potential development mistakes and insecure practices, 
+      such usage of insecure functions or libraries,
+      forgotten boundary checks when operating on arrays, and many other sources
+      of security weakness.
+      Usually the output of such a tool is in the form of a report that
+      needs to be manually triaged to determine if each reported issue is a false positive
+      or a real mistake. 
+      While static development tools are constantly improving and 
+      over time are able
+      to offer better and better coverage, lower false positive rates, 
+      and discover more weaknesses, 
+      it is important to remember that these tools (as any others) do
+      not guarantee finding all weaknesses in the scanned component.
+      Other methods should be used to complement static analysis.</p>
+
+      <p><strong>Examples of tools:</strong>
+      Many commercial and open source tools exist that primarily differ on the
+      source code languages that they can process as input. Our major suggestion
+      would be to choose a well-established, mature tool that is actively
+      supported and developed. Some examples include Klocwork [<cite><a class="bibref" data-link-type="biblio" href="#bib-klocwork" title="Klocwork. Faster delivery of secure, reliable, and conformant code">Klocwork</a></cite>],
+      Coverity [<cite><a class="bibref" data-link-type="biblio" href="#bib-coverity" title="Coverity Tutorial: Introduction to Coverity">Coverity</a></cite>], and Checkmarx [<cite><a class="bibref" data-link-type="biblio" href="#bib-checkmarx" title="Checkmarx project page">Checkmarx</a></cite>].
+      Also, while some of these tools are commercial and require a license
+      to use, they often do provide a free scanning service for open source projects.
+      One example of such service is the online Coverity service [<cite><a class="bibref" data-link-type="biblio" href="#bib-coverityonline" title="Coverity online scanning service">CoverityOnline</a></cite>].
+      </p>
+      </section>
+
+      <section id="known-vulnerability-checking">
+      <h5 id="x9-4-1-2-known-vulnerability-checking"><bdi class="secno">9.4.1.2 </bdi>Known vulnerability checking<a class="self-link" aria-label="§" href="#known-vulnerability-checking"></a></h5>
+      <p>In addition to checking for development mistakes in new code,
+      it is also important to check that programs do not include
+      vulnerable third-party libraries or utilities with known weaknesses or 
+      vulnerabilities. There are many tools developed
+      for this purpose and on a high level they work by scanning executable binaries
+      (or source code for non-compiled languages) or application packages in a search
+      for vulnerable components, such as old versions of libraries that are vulnerable
+      to known attacks. 
+      The information about weaknesses and vulnerabilities usually comes from
+      the open NIST database which is updated regularly since
+      new weaknesses and vulnerabilities are reported all the time.  
+      This also implies that the analysis should be repeated regularly, ideally
+      daily and as part of an automated build process, using the latest version
+      of the weakness and vulnerability database.  As new weaknesses, vulnerabilities,  
+      and exploits are found, components may then have to be updated to mitigate any
+      new weaknesses and vulnerabilities.
+      </p>
+
+      <p><strong>Examples of tools:</strong>
+      Just as with static code analyzer software, our major suggestion
+      would be to choose a well-established, mature tool that is actively
+      supported and developed. Some examples include Protecode [<cite><a class="bibref" data-link-type="biblio" href="#bib-protecode" title="Black Duck Software Composition Analysis">Protecode</a></cite>],
+      Dependency-check [<cite><a class="bibref" data-link-type="biblio" href="#bib-owasp-dependency-check" title="OWASP Dependency Check">OWASP-Dependency-Check</a></cite>], and Snyk [<cite><a class="bibref" data-link-type="biblio" href="#bib-snyk" title="A developer-first solution that automates finding and fixing vulnerabilities in your dependencies">Snyk</a></cite>].
+      </p>
+      </section>
+    </section>
+
+
+    <section id="runtime-weakness-discovery">
+      <h4 id="x9-4-2-runtime-dynamic-weakness-discovery"><bdi class="secno">9.4.2 </bdi>Runtime (Dynamic) Weakness Discovery<a class="self-link" aria-label="§" href="#runtime-weakness-discovery"></a></h4>
+      <p>In contrast to static weakness discovery, runtime
+      weakness discovery does not require access to the source code or
+      compiled binaries of a component, but merely an ability to access a
+      component's exposed interfaces (especially network-facing interfaces)
+      and/or an ability to observe and modify the protocol and the 
+      component's communication with other components.
+      </p><p>
+      The goal of runtime weakness discovery is to find an interface input 
+      or protocol modification that leads to unintended behavior, such as component
+      deadlock or crash.  Even if a crash is not the desired outcome for an attacker,
+      a crash is also an indication of a weakness, such as a 
+      lack of input validation, that can be used in more sophisticated exploits.
+      Of course finding inputs that cause such problems and mitigating them
+      also increases the overall robustness and quality of the code.
+      </p><p>
+      Just as with static weakness discovery, many tools exist to
+      help with this task.  For web services, it is generally a bit harder to reach full
+      automation (with the exception of fuzz testing) here, and the best results
+      can usually only be achieved by combining both manual and automated tasks.
+      However, the advent of API metadata such as OpenAPI and the WoT Thing Description
+      may in the future lead to more sophisticated and automated tooling in this
+      area.
+      </p>
+
+      <section id="fuzz-testing">
+      <h5 id="x9-4-2-1-fuzz-testing"><bdi class="secno">9.4.2.1 </bdi>Fuzz Testing<a class="self-link" aria-label="§" href="#fuzz-testing"></a></h5>
+      <p>Fuzz testing is one of the most well known and used runtime weakness
+      discovery methods. It is well-automated, many tools exist for common
+      protocols and payloads.  
+      It is a very powerful method for weakness discovery.
+      Fuzz testing works by generating (randomly or pattern-based) highly
+      varied input for a specific network exposed interface or protocol payload,
+      sending this input to the tested component, and observing the result.
+      If a "desired" outcome happens (such as tested component crashes), the
+      corresponding input and details of the crash are recorded for the
+      analyst to manually process.</p>
+
+      <p>The biggest challenge with fuzz testing is usually to be able to
+      generate the randomized input in a form that is still "correct enough"
+      that it does not get discarded by the lower layers of software or network stack. 
+      For example, if the fuzz testing goal is to test how a network-enabled thermostat 
+      processes numeric values on its temperature setting HTTP-exposed interface,
+      it is important that fuzzed requests have valid HTTP headers, body
+      structure, etc. This way the requests will get delivered all the way
+      to the high-level logic inside the device runtime 
+      and will not discarded by lower-level HTTP message validation
+      and processing components.
+      </p>
+
+      <p><strong>Examples of tools:</strong>
+      There are numerous tools exists for fuzzing
+      HTTP(S)-exposed interfaces. 
+      Examples include Burp Suite [<cite><a class="bibref" data-link-type="biblio" href="#bib-burp" title="Burp Suite Web vulnerability scanner">Burp</a></cite>], Wfuzz [<cite><a class="bibref" data-link-type="biblio" href="#bib-wfuzz" title="Wfuzz. The web application Bruteforcer">Wfuzz</a></cite>], and Wapiti [<cite><a class="bibref" data-link-type="biblio" href="#bib-wapiti" title="Wapiti - The web-application vulnerability scanner">wapiti</a></cite>].
+      Newer protocols, like COAP(S) and MQTT(S), have considerably fewer tools
+      available.  However some do exist.
+      Examples for CoAP(S) include fuzzcoap [<cite><a class="bibref" data-link-type="biblio" href="#bib-fuzzcoap" title="FuzzCoAP - Fuzzing for Robustness and Security Testing of CoAP Servers">FuzzCoAP</a></cite>] and CoAP Peach Pit (from Peach Fuzzer)
+      [<cite><a class="bibref" data-link-type="biblio" href="#bib-peachpit-coap" title="CoAP Peach Pit User Guide">PeachPit-COAP</a></cite>].  Some of these may still in the experimental phase.</p>
+      </section>
+
+      <section id="protocol-analysis">
+      <h5 id="x9-4-2-2-protocol-analysis"><bdi class="secno">9.4.2.2 </bdi>Protocol Analysis<a class="self-link" aria-label="§" href="#protocol-analysis"></a></h5>
+      <p>In addition to automated Fuzz testing, one might be able to discover
+      weaknesses by manually analyzing protocol elements such as
+      headers, payload, and attributes. 
+      For example, an analyst might look for the use of older encryption 
+      or authentication algorithms, or the use of insecure combinations of protocol options.
+      While the actual protocol analysis is a manual process, 
+      many tools exist to capture the protocol traffic, parse it
+      according to the protocol, and present it to the analyst in an organized fashion.
+
+      </p><p><strong>Examples of tools:</strong> Examples of network protocol
+      analyzers include Wireshark [<cite><a class="bibref" data-link-type="biblio" href="#bib-wireshark" title="Wireshark project page">Wireshark</a></cite>] and tcpdump [<cite><a class="bibref" data-link-type="biblio" href="#bib-tcpdump" title="tcpdump and libpcap project page">tcpdump</a></cite>]. </p>
+      </section>
+
+      <section id="vulnerability-scanners">
+      <h5 id="x9-4-2-3-vulnerability-scanners"><bdi class="secno">9.4.2.3 </bdi>Vulnerability Scanners<a class="self-link" aria-label="§" href="#vulnerability-scanners"></a></h5>
+      <p>There are many tools available that attempt to perform runtime
+      testing for known vulnerabilities. They usually operate
+      by attempting to run a known set of exploits or weakness trigger inputs
+      against the target and report the outcomes. 
+      Such tools should be used in combination with other testing tools
+      in order to obtain a more complete runtime weakness and vulnerability discovery result.
+      </p>
+
+      <p><strong>Examples of tools:</strong> While many different vulnerability
+      scanners exist, some specifically target web applications and web server
+      service vulnerabilities and are therefore more focused. 
+      Examples include w3af [<cite><a class="bibref" data-link-type="biblio" href="#bib-w3af" title="Web Application Attack and Audit Framework">w3af</a></cite>],
+      the Burp vulnerability scanner [<cite><a class="bibref" data-link-type="biblio" href="#bib-burp" title="Burp Suite Web vulnerability scanner">Burp</a></cite>], Nikto [<cite><a class="bibref" data-link-type="biblio" href="#bib-nikto" title="Nikto web server scanner">Nikto</a></cite>], and WATOBO [<cite><a class="bibref" data-link-type="biblio" href="#bib-watobo" title="WATOBO. The Web Application Toolbox">WATOBO</a></cite>].
+      </p>
+      </section>
+      </section>
+
+      <section id="exploitation">
+      <h4 id="x9-4-3-exploitation"><bdi class="secno">9.4.3 </bdi>Exploitation<a class="self-link" aria-label="§" href="#exploitation"></a></h4>
+        <p>When a weakness or a set of weaknesses is found for a component,
+        it is important to estimate the exploitation risk level for them.
+        Exploitation risk level aims to determine if a particular
+        weakness can be converted into a vulnerability and
+        used by an attacker to achieve particular attack end goals,
+        such as privilege escalation, authorization bypass, denial of service, and so on.
+        This step can help to prioritize the order in which weaknesses must be mitigated.
+        Developers should fix the most easily exploitable vulnerabilities first and 
+        then continuing with others in decreasing level of severity or probability of
+        exploitation.
+        Some tools mentioned in section <a href="#protocol-analysis" class="sec-ref">§&nbsp;<bdi class="secno">9.4.2.2 </bdi>Protocol Analysis</a> can be used to test
+        the exploitabilty of a particular weakness. Additionally, for known
+        vulnerabilities, the Exploit-DB [<cite><a class="bibref" data-link-type="biblio" href="#bib-exploit-db" title="Exploit database project page">exploit-db</a></cite>] database hosts many public exploits
+        and allows to search by the CVE number of the associated (known) vulnerability.
+        However, it is important to remember that it is generally very hard to reliably
+        determine the exploitability of a given weakness: if an exploit cannot be
+        found, it does not guarantee that the weakness is not exploitable. Moreover,
+        for some weaknesses, they might not be exploitable on their own, or may
+        only be weakly exploitable, but may still play
+        an important role in the attacker exploitation chain as a stepping stone towards
+        the end exploitation goal.
+        Therefore, it is strongly encouraged to fix or mitigate all 
+        weaknesses discovered in analyzed components.</p>
+    </section>
+    </section>
+
+    <section id="security-testing-plan-framework">
+    <h3 id="x9-5-security-testing-plan-framework"><bdi class="secno">9.5 </bdi>Security Testing Plan Framework<a class="self-link" aria-label="§" href="#security-testing-plan-framework"></a></h3>
+      <p>Given the above background, we can now outline a testing plan framework for WoT Systems.
+      This is just an outline and would have to be expanded and adapted for the specific
+      circumstances and application area of the WoT System under test.  In particular, some
+      tool choices may depend on the programming language, build environment, network environment,
+      and budget (for non-free tools).  Also the testing procedure will be different for
+      purpose-built devices and services vs. pre-existing devices and services.</p>
+      <ol>
+      <li><strong><a href="#static-weakness-discovery">Static Weakness Discovery</a></strong> 
+        <ol>
+        <li><strong><a href="#static-code-analysis">Static Code Analysis:</a></strong>
+        If source code is available, a static code checker should be used to check
+        for weaknesses in new purpose-written code.</li>
+        <li><strong><a href="#known-vulnerability-checking">Known Vulnerability Checking:</a></strong>
+        If binaries and/or a list of package dependencies are available, a vulnerability
+        checker should be used to check for known weaknesses and vulnerabilities in any libraries used.
+        </li>
+        </ol>
+      </li>
+      <li><strong><a href="#runtime-weakness-discovery">Runtime Weakness Discovery</a></strong> 
+        appropriate tools 
+        such as <a href="#fuzz-testing">Fuzz Testing</a>,
+        <a href="#protocol-analysis">Protocol Analysis</a>,
+        and <a href="#vulnerability-scanners">Vulnerability Scanners</a>
+        can be discover problems even when only the network interface is
+        available, and are complementary to other kinds of checks.
+     </li>
+     <li><strong><a href="#exploitation">Exploitation Analysis</a></strong> 
+        This can be used to prioritize which weaknesses and vulnerabilities should be addressed
+        first or whether a given vulnerable system can even be used in a given
+        environment. 
+     </li>
+     </ol> 
+     <p>Ideally, security testing should be integrated into the development process
+     and all discovered weaknesses addressed as soon as possible.  If this is
+     not possible, weaknesses should be prioritized based on the threat
+     model and potential for exploitation and addressed in priority order.
+     </p>
+    </section> 
+            
+    <section id="suggested-testing-frequency">
+    <h3 id="x9-6-suggested-testing-frequency"><bdi class="secno">9.6 </bdi>Suggested Testing Frequency<a class="self-link" aria-label="§" href="#suggested-testing-frequency"></a></h3>
+        <p>The actual detailed test procedure depends on the type of activity, the WoT
+        device setup and the actual test tool used. 
+        However, below are our general recommendations
+        for the frequency of different testing activities:</p>
+        <ol>
+        <li><strong><a href="#static-weakness-discovery">Static Weakness Discovery</a></strong> 
+        should be done regularly,
+        ideally integrated into the development work flow for a WoT component.
+        This is important, since any even small code changes can introduce
+        development mistakes, or alternatively new weaknesses can be 
+        discovered in the libraries that a program depends on.  
+        New weaknesses and vulnerabilities
+        are discovered in existing libraries almost daily.
+        </li>
+        <li><strong><a href="#runtime-weakness-discovery">Runtime Weakness Discovery</a></strong> 
+        should be also done on a regular basis, for example for each major release
+        or development milestone.
+        </li>
+        <li><strong><a href="#exploitation">Exploitation Analysis</a></strong> 
+        should be done occasionally,
+        whenever possible.  
+        It is the most time and resource consuming
+        activity, often requires external resources with specialized knowledge,
+        and cannot in general be automated.
+        </li>
+        </ol>
+    </section>
+
+    <section id="summary">
+      <h3 id="x9-7-summary"><bdi class="secno">9.7 </bdi>Summary<a class="self-link" aria-label="§" href="#summary"></a></h3>
+      <p>A security testing plan focused on weakness and vulnerability discovery
+      has been presented that leverages existing tools and approaches for web services
+      and emerging tools for new IoT-oriented network interfaces.
+      A testing plan should be developed suitable for each system developed using the
+      WoT Architecture but will generally consist of three stages:
+      <a href="#static-weakness-discovery">static weakness discovery</a>,
+      <a href="#runtime-weakness-discovery">runtime weakness discovery</a>,
+      and <a href="#exploitation">Exploitation Analysis</a>.
+      A vulnerability is a weakness with a known exploit and should have priority for
+      mitigation, but all weaknesses may potentially lead to vulnerabilities and
+      ideally all weaknesses would be mitigated or corrected.
+      In general, a WoT Thing Description can be used to describe both secure and
+      insecure systems, and in fact this is necessary to support existing devices,
+      which may or may not themselves be intrinsically secure.
+      However, WoT Thing Descriptions provide new opportunities for understanding and
+      planning security testing and mitigations.
+      </p>
+</section>
+   
+    </section>
+
+
+    <section id="terminology">
+      <h2 id="e-terminology"><bdi class="secno">10. </bdi>Terminology<a class="self-link" aria-label="§" href="#e-terminology"></a></h2>
+
+      <p>
+        Please refer to  
+	[<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>] 
+	for definitions of the following terms used in this document: WoT Consumer,
+    WoT Thing, WoT Servient, WoT Protocol Binding, WoT Binding Templates, WoT Intermediary,
+    WoT Thing Directory, WoT Thing Description, Exposed Thing, WoT Interface, WoT Runtime, and WoT Scripting API.
+      </p>
+        <p>
+        Additionally we define the following terms:
+        </p><dl>
+          <dt>WoT System:</dt><dd>
+           A set of WoT-enabled devices and the communication links between them.
+          </dd>
+          <dt>WoT Device:</dt><dd>
+          A physical device that enables WoT layer on top of its software stack.
+          </dd>
+      </dl>
+      <p></p>
+    <p>Within the <a href="#security-validation">Security Validation</a> section
+     we are using the security vocabulary defined by the ITU-T [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1500" title="ITU-T Rec. X.1500 Overview of cybersecurity information exchange">ITUx1500</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1520" title="ITU-T Rec. X.1520 Common vulnerabilities and exposures">ITUx1520</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1524" title="ITU-T Rec. X.1524 Common weakness enumeration">ITUx1524</a></cite>]
+      for the following terms:
+      </p><dl>
+          <dt>Vulnerability:</dt><dd>
+           Any weakness in software that could be exploited to violate a system or the information 
+           it contains 
+           [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1500" title="ITU-T Rec. X.1500 Overview of cybersecurity information exchange">ITUx1500</a></cite>].
+          </dd>
+          <dt>Weakness:</dt><dd>
+          A shortcoming or imperfection in the software code, design, architecture, or deployment that, 
+          could, at some point become a vulnerability, 
+          or contribute to the introduction of other vulnerabilities
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1500" title="ITU-T Rec. X.1500 Overview of cybersecurity information exchange">ITUx1500</a></cite>].
+          </dd>
+      </dl>
+      In short, a weakness is a <em>potential</em> vulnerability.
+      A weakness only becomes an <em>actual</em> vulnerability once an exploit is known.
+      <p></p>
+
+    </section>
+
+    <section id="changes" class="appendix">
+      <h2 id="e-changes"><bdi class="secno">A. </bdi>Change Log<a class="self-link" aria-label="§" href="#e-changes"></a></h2>
+      <section id="changes-from-second-release">
+        <h3 id="e-changes-from-second-release"><bdi class="secno">A.1 </bdi>Changes from Second Release<a class="self-link" aria-label="§" href="#e-changes-from-second-release"></a></h3>
+        <ul>
+        <li>Addition of references to published versions of 
+            the [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-thing-description" title="Web of Things (WoT) Thing Description">WoT-Thing-Description</a></cite>],
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-binding-templates" title="Web of Things (WoT) Binding Templates">WoT-Binding-Templates</a></cite>], and
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-scripting-api" title="Web of Things (WoT) Scripting API">WoT-Scripting-API</a></cite>] documents,
+            as well as the following new references:
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-burp" title="Burp Suite Web vulnerability scanner">Burp</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-checkmarx" title="Checkmarx project page">Checkmarx</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-coverity" title="Coverity Tutorial: Introduction to Coverity">Coverity</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-coverityonline" title="Coverity online scanning service">CoverityOnline</a></cite>],
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-exploit-db" title="Exploit database project page">exploit-db</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-fuzzcoap" title="FuzzCoAP - Fuzzing for Robustness and Security Testing of CoAP Servers">FuzzCoAP</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1500" title="ITU-T Rec. X.1500 Overview of cybersecurity information exchange">ITUx1500</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1520" title="ITU-T Rec. X.1520 Common vulnerabilities and exposures">ITUx1520</a></cite>],
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1524" title="ITU-T Rec. X.1524 Common weakness enumeration">ITUx1524</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-klocwork" title="Klocwork. Faster delivery of secure, reliable, and conformant code">Klocwork</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-nikto" title="Nikto web server scanner">Nikto</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-owa18" title="Web Service Security Testing">Owa18</a></cite>],
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-owasp-dependency-check" title="OWASP Dependency Check">OWASP-Dependency-Check</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-peachpit-coap" title="CoAP Peach Pit User Guide">PeachPit-COAP</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-protecode" title="Black Duck Software Composition Analysis">Protecode</a></cite>],
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-snyk" title="A developer-first solution that automates finding and fixing vulnerabilities in your dependencies">Snyk</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-tcpdump" title="tcpdump and libpcap project page">tcpdump</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-w3af" title="Web Application Attack and Audit Framework">w3af</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-wapiti" title="Wapiti - The web-application vulnerability scanner">wapiti</a></cite>], [<cite><a class="bibref" data-link-type="biblio" href="#bib-watobo" title="WATOBO. The Web Application Toolbox">WATOBO</a></cite>],
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-wfuzz" title="Wfuzz. The web application Bruteforcer">Wfuzz</a></cite>], and [<cite><a class="bibref" data-link-type="biblio" href="#bib-wireshark" title="Wireshark project page">Wireshark</a></cite>].</li>
+        <li>The name was changed from
+            <em>Web of Things (WoT) Security and Privacy Considerations</em>
+            to <em>Web of Things (WoT) Security and Privacy Guidelines</em>.
+            This change was made to avoid
+            confusion with the "considerations" sections of individual
+            WoT documents.</li>
+        <li>Revision and clarification of the attack surfaces 
+            of a WoT System described in  
+            <a href="#wot-threat-model-attack-surfaces" class="sec-ref">§&nbsp;<bdi class="secno">3.2.4 </bdi>Attack Surfaces</a>.</li>
+        <li>Empty section for <em>Secure Practices for Thing Directory
+            Interaction Protocols</em> was removed.</li>
+        <li>Addition of <a href="#security-validation" class="sec-ref">§&nbsp;<bdi class="secno">9. </bdi>Security Validation</a>,
+            which provides security testing guidance for WoT Systems.
+        </li><li>Revision of terminology usage to be consistent with the definitions
+            in [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>].
+        </li><li>Revision of <a href="#terminology" class="sec-ref">§&nbsp;<bdi class="secno">10. </bdi>Terminology</a>
+            to state specific terms
+            used from [<cite><a class="bibref" data-link-type="biblio" href="#bib-wot-architecture" title="Web of Things (WoT) Architecture">WoT-Architecture</a></cite>], add
+            definitions of terms used only in this document, and reference
+            externally defined terms in [<cite><a class="bibref" data-link-type="biblio" href="#bib-itux1500" title="ITU-T Rec. X.1500 Overview of cybersecurity information exchange">ITUx1500</a></cite>].
+        </li></ul>
+      </section>
+      <section id="changes-from-First-release">
+        <h3 id="e-changes-from-first-release"><bdi class="secno">A.2 </bdi>Changes from First Release<a class="self-link" aria-label="§" href="#e-changes-from-first-release"></a></h3>
+        <ul>
+        <li>Replace inline description of <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy with link to 
+            <a href="https://www.w3.org/Consortium/Patent-Policy/">external document</a>.</li>
+        <li>Added <a href="#wot-device-lifecycle" class="sec-ref">§&nbsp;<bdi class="secno">2. </bdi>Lifecycle of a WoT Device</a> describing the states and
+            transitions of a device throughout its lifetime.</li>
+        <li>Added MQTT as a focus protocol.</li>
+        <li>Expanded and clarified role and threat definitions in
+            <a href="#wot-threat-model" class="sec-ref">§&nbsp;<bdi class="secno">3.2 </bdi>Threat Model</a>.</li>
+        <li>Added WoT Thing Directory to items (currently) out of scope.</li>
+        <li>Added Side Channel threat to 
+            <a href="#scenario-1-home-environment" class="sec-ref">§&nbsp;<bdi class="secno">3.3.1 </bdi>Scenario 1 - Home Environment</a>.</li>
+        <li>Added <a href="#scenario-2-business-corporate-environment" class="sec-ref">§&nbsp;<bdi class="secno">3.3.2 </bdi>Scenario 2 - Business/Corporate Environment</a>
+            describing threats in an office building environment.</li>
+        <li>Added <a href="#scenario-3-industrial-critical-infrastructure-environment" class="sec-ref">§&nbsp;<bdi class="secno">3.3.3 </bdi>Scenario 3 - Industrial/Critical Infrastructure Environment</a>
+            describing threats in an industrial environment.</li>
+        <li>Added <a href="#wot-privacy" class="sec-ref">§&nbsp;<bdi class="secno">4. </bdi>Privacy Considerations</a>.</li>
+        <li>Revised <a href="#security-mitigations" class="sec-ref">§&nbsp;<bdi class="secno">7. </bdi>Best Security Practices and Mitigations for WoT Systems</a>, and
+            added recommended mitigations.</li>
+        <li>Revised <a href="#wot-client-server-basic" class="sec-ref">§&nbsp;<bdi class="secno">8.1 </bdi>Basic Interaction between WoT Thing and WoT Consumer</a> to include OCF
+            as an example, and describe use of CoAPS and DTLS in this
+            case.</li>
+        <li>Added <a href="#wot-client-server-double-proxy" class="sec-ref">§&nbsp;<bdi class="secno">8.3 </bdi>Basic Interaction between WoT Thing and WoT Consumer via a Split Proxy</a>
+            and <a href="#wot-client-server-tunnel" class="sec-ref">§&nbsp;<bdi class="secno">8.4 </bdi>Basic Interaction between WoT Thing and WoT Consumer via a Tunnel</a> to describe
+            two possible strategies for traversing NATs.
+        </li>
+        </ul>
+      </section>
+    </section>
+
+    
+    <script id="dstimer" language="javascript">
+//<![CDATA[
+if(dschk() == 1) { if(typeof (dsSetTimers) != "undefined") { dsSetTimers(1454572750,1454589711,43200,86400,180,1454589796 - parseInt(""+(new Date()).getTime()/1000),1);}}
+//]]>
+    </script>
+  
+
+<section id="references" class="appendix"><h2 id="b-references"><bdi class="secno">B. </bdi>References<a class="self-link" aria-label="§" href="#references"></a></h2><section id="informative-references">
+      <h3 id="b-1-informative-references"><bdi class="secno">B.1 </bdi>
+        Informative references
+      <a class="self-link" aria-label="§" href="#informative-references"></a></h3>
+    <dl class="bibliography">
+      <dt id="bib-aead08">[AEAD08]</dt><dd><a href="https://tools.ietf.org/html/rfc5116"><cite>An Interface and Algorithms for Authenticated Encryption</cite></a>.  IETF. January 2008. URL: <a href="https://tools.ietf.org/html/rfc5116">https://tools.ietf.org/html/rfc5116</a></dd><dt id="bib-bel13">[Bel13]</dt><dd><a href="https://csrc.nist.gov/csrc/media/events/workshop-on-improving-trust-in-the-online-marketpl/documents/presentations/bellovin_ca-workshop2013.pdf"><cite>Web Security in the Real World</cite></a>. S. Bellovin.  Workshop on Improving Trust in the Online Marketplace, NIST. April 2013. URL: <a href="https://csrc.nist.gov/csrc/media/events/workshop-on-improving-trust-in-the-online-marketpl/documents/presentations/bellovin_ca-workshop2013.pdf">https://csrc.nist.gov/csrc/media/events/workshop-on-improving-trust-in-the-online-marketpl/documents/presentations/bellovin_ca-workshop2013.pdf</a></dd><dt id="bib-bel89">[Bel89]</dt><dd><a href="https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf"><cite>Security Problems in the TCP-IP Protocol Suite</cite></a>. S. Bellovin.  Computer Communication Review, Vol. 19, No. 2. April 1989. URL: <a href="https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf">https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf</a></dd><dt id="bib-ber14">[Ber14]</dt><dd><a href="http://www.cloudidentity.com/blog/2014/04/22/authentication-protocols-web-ux-and-web-api/"><cite>Authentication Protocols, Web UX and Web API</cite></a>. V. Bertocci. April 2014. URL: <a href="http://www.cloudidentity.com/blog/2014/04/22/authentication-protocols-web-ux-and-web-api/">http://www.cloudidentity.com/blog/2014/04/22/authentication-protocols-web-ux-and-web-api/</a></dd><dt id="bib-bor14">[Bor14]</dt><dd><a href="https://tools.ietf.org/rfc/rfc7228.txt"><cite>Terminology for Constrained-Node Networks</cite></a>. C. Bormann; et al..  IETF RFC 7228. May 2014. URL: <a href="https://tools.ietf.org/rfc/rfc7228.txt">https://tools.ietf.org/rfc/rfc7228.txt</a></dd><dt id="bib-bru14">[Bru14]</dt><dd><a href="https://www.cs.utexas.edu/~shmat/shmat_oak14.pdf"><cite>Using Frankencerts for Automated Adversarial Testing of Certificate Validation in SSL/TLS Implementations</cite></a>. C. Brubaker; et al..  IEEE Security Privacy. 2014. URL: <a href="https://www.cs.utexas.edu/~shmat/shmat_oak14.pdf">https://www.cs.utexas.edu/~shmat/shmat_oak14.pdf</a></dd><dt id="bib-burp">[Burp]</dt><dd><a href="https://portswigger.net/burp"><cite>Burp Suite Web vulnerability scanner</cite></a>. URL: <a href="https://portswigger.net/burp">https://portswigger.net/burp</a></dd><dt id="bib-cbor17">[CBOR17]</dt><dd><a href="https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf"><cite>CBOR Web Token (CWT)</cite></a>.  IETF. June 2017. Internet-Draft. URL: <a href="https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf">https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf</a></dd><dt id="bib-checkmarx">[Checkmarx]</dt><dd><a href="https://www.checkmarx.com/"><cite>Checkmarx project page</cite></a>. URL: <a href="https://www.checkmarx.com/">https://www.checkmarx.com/</a></dd><dt id="bib-coo13">[Coo13]</dt><dd><a href="https://tools.ietf.org/html/rfc6973"><cite>Privacy Considerations for Internet Protocols</cite></a>. A. Cooper; et al.  IETF RFC 6973 (IAB Guideline). July 2013. URL: <a href="https://tools.ietf.org/html/rfc6973">https://tools.ietf.org/html/rfc6973</a></dd><dt id="bib-core-rd">[CoRE-RD]</dt><dd><a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-11"><cite>CoRE Resource Directory</cite></a>.  IETF. 03 July 2017. Internet-Draft. URL: <a href="https://tools.ietf.org/html/draft-ietf-core-resource-directory-11">https://tools.ietf.org/html/draft-ietf-core-resource-directory-11</a></dd><dt id="bib-cose17">[COSE17]</dt><dd><a href="https://tools.ietf.org/html/rfc8152"><cite>CBOR Object Signing and Encryption (COSE)</cite></a>.  IETF. May 2017. URL: <a href="https://tools.ietf.org/html/rfc8152">https://tools.ietf.org/html/rfc8152</a></dd><dt id="bib-coverity">[Coverity]</dt><dd><a href="https://community.synopsys.com/s/article/Coverity-Tutorial-Introduction-to-Coverity"><cite>Coverity Tutorial: Introduction to Coverity</cite></a>. URL: <a href="https://community.synopsys.com/s/article/Coverity-Tutorial-Introduction-to-Coverity">https://community.synopsys.com/s/article/Coverity-Tutorial-Introduction-to-Coverity</a></dd><dt id="bib-coverityonline">[CoverityOnline]</dt><dd><a href="https://scan.coverity.com"><cite>Coverity online scanning service</cite></a>. URL: <a href="https://scan.coverity.com">https://scan.coverity.com</a></dd><dt id="bib-dur13">[Dur13]</dt><dd><a href="https://conferences.sigcomm.org/imc/2013/papers/imc257-durumericAemb.pdf"><cite>Analysis of the HTTPS Certificate Ecosystem</cite></a>. Z. Durumeric; et al..  Proc. of the 2013 conference on Internet measurement conference. October 2013. URL: <a href="https://conferences.sigcomm.org/imc/2013/papers/imc257-durumericAemb.pdf">https://conferences.sigcomm.org/imc/2013/papers/imc257-durumericAemb.pdf</a></dd><dt id="bib-ell00">[Ell00]</dt><dd><a href="https://www.schneier.com/paper-pki.pdf"><cite>Ten Risks of PKI: What You’re not Being Told about Public Key Infrastructure</cite></a>. C. Ellison; B. Schneier.  Computer Security Journal, v 16, n 1,. 2000. URL: <a href="https://www.schneier.com/paper-pki.pdf">https://www.schneier.com/paper-pki.pdf</a></dd><dt id="bib-exploit-db">[exploit-db]</dt><dd><a href="https://www.exploit-db.com/"><cite>Exploit database project page</cite></a>. URL: <a href="https://www.exploit-db.com/">https://www.exploit-db.com/</a></dd><dt id="bib-fu01">[Fu01]</dt><dd><a href="https://pdos.csail.mit.edu/papers/webauth:sec10.pdf"><cite>Dos and Don’ts of Client Authentication on the Web</cite></a>. K. Fu; et al..  Proc. 10th USENIX Security Symposium. August 2001. URL: <a href="https://pdos.csail.mit.edu/papers/webauth:sec10.pdf">https://pdos.csail.mit.edu/papers/webauth:sec10.pdf</a></dd><dt id="bib-fuzzcoap">[FuzzCoAP]</dt><dd><a href="https://github.com/bsmelo/fuzzcoap"><cite>FuzzCoAP - Fuzzing for Robustness and Security Testing of CoAP Servers</cite></a>. URL: <a href="https://github.com/bsmelo/fuzzcoap">https://github.com/bsmelo/fuzzcoap</a></dd><dt id="bib-garcia17">[Garcia17]</dt><dd><a href="https://datatracker.ietf.org/doc/draft-irtf-t2trg-iot-seccons/"><cite>State-of-the-Art and Challenges for the Internet of Things Security</cite></a>. O. Garcia-Morchon; S. Kumar; M. Sethi. URL: <a href="https://datatracker.ietf.org/doc/draft-irtf-t2trg-iot-seccons/">https://datatracker.ietf.org/doc/draft-irtf-t2trg-iot-seccons/</a></dd><dt id="bib-geo12">[Geo12]</dt><dd><a href="https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf"><cite>The Most Dangerous Code in the World: Validating SSL Certificates in Non-Browser Software</cite></a>. M. Georgiev; et al..  Proc. of the 2012 ACM conference on Computer and communications security. 2012. URL: <a href="https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf">https://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf</a></dd><dt id="bib-gol03">[Gol03]</dt><dd><a href="http://www.wisdom.weizmann.ac.il/~oded/foc-sur01.html"><cite>Cryptography and Cryptographic Protocols</cite></a>. O. Goldreich.  Distributed Computing, vol. 16. 2003. URL: <a href="http://www.wisdom.weizmann.ac.il/~oded/foc-sur01.html">http://www.wisdom.weizmann.ac.il/~oded/foc-sur01.html</a></dd><dt id="bib-gre14">[Gre14]</dt><dd><a href="https://blog.cryptographyengineering.com/2014/03/19/how-do-you-know-if-rng-is-working/"><cite>How do you know if an RNG is working?</cite></a>. M. Green. March 2014. URL: <a href="https://blog.cryptographyengineering.com/2014/03/19/how-do-you-know-if-rng-is-working/">https://blog.cryptographyengineering.com/2014/03/19/how-do-you-know-if-rng-is-working/</a></dd><dt id="bib-gut02">[Gut02]</dt><dd><a href="https://www.cs.auckland.ac.nz/~pgut001/pubs/notdead.pdf"><cite>PKI: It’s Not Dead, Just Resting</cite></a>. P. Gutman.  IEEE Computer, vol. 35, no. 8. Aug. 2002. URL: <a href="https://www.cs.auckland.ac.nz/~pgut001/pubs/notdead.pdf">https://www.cs.auckland.ac.nz/~pgut001/pubs/notdead.pdf</a></dd><dt id="bib-hea13">[Hea13]</dt><dd><a href="https://googleblog.blogspot.de/2013/02/an-update-on-our-war-against-account.html"><cite>An update on our war against account hijackers</cite></a>. M. Hearn. Feb 2013. URL: <a href="https://googleblog.blogspot.de/2013/02/an-update-on-our-war-against-account.html">https://googleblog.blogspot.de/2013/02/an-update-on-our-war-against-account.html</a></dd><dt id="bib-ietface">[IETFACE]</dt><dd><a href="https://tools.ietf.org/wg/ace/"><cite>IETF Authentication and Authorization for Constrained Environments (ACE)</cite></a>. URL: <a href="https://tools.ietf.org/wg/ace/">https://tools.ietf.org/wg/ace/</a></dd><dt id="bib-iic15">[Iic15]</dt><dd><a href="http://www.iiconsortium.org/IIRA.htm"><cite>Industrial Internet Reference Architecture</cite></a>. Industrial Internet Consortium. June 2015. URL: <a href="http://www.iiconsortium.org/IIRA.htm">http://www.iiconsortium.org/IIRA.htm</a></dd><dt id="bib-iicra17">[IicRA17]</dt><dd><a href="https://www.iiconsortium.org/IIRA.htm"><cite>The Industrial Internet of Things Volume G1: Reference Architecture</cite></a>. Industrial Internet Consortium.  IIC:PUB:G1:V1.80:20170131. Jan 2017. URL: <a href="https://www.iiconsortium.org/IIRA.htm">https://www.iiconsortium.org/IIRA.htm</a></dd><dt id="bib-iicsf16">[IicSF16]</dt><dd><a href="https://www.iiconsortium.org/IISF.htm"><cite>The Industrial Internet of Things Volume G4: Security Framework</cite></a>. Industrial Internet Consortium.  IIC:PUB:G4:V1.0:PB:20160926. Sept 2016. URL: <a href="https://www.iiconsortium.org/IISF.htm">https://www.iiconsortium.org/IISF.htm</a></dd><dt id="bib-isf17">[ISF17]</dt><dd><a href="https://iotsecurityfoundation.org/best-practice-guidelines/"><cite>IoT Security Foundation Best Practice Guidelines</cite></a>. IoT Security Foundation. May 2017. URL: <a href="https://iotsecurityfoundation.org/best-practice-guidelines/">https://iotsecurityfoundation.org/best-practice-guidelines/</a></dd><dt id="bib-itux1500">[ITUx1500]</dt><dd><a href="https://www.itu.int/rec/T-REC-X.1500"><cite>ITU-T Rec. X.1500 Overview of cybersecurity information exchange</cite></a>. ITU-T SG17.  International Telecommunication Union. Apr 2011. URL: <a href="https://www.itu.int/rec/T-REC-X.1500">https://www.itu.int/rec/T-REC-X.1500</a></dd><dt id="bib-itux1520">[ITUx1520]</dt><dd><a href="https://www.itu.int/rec/T-REC-X.1520"><cite>ITU-T Rec. X.1520 Common vulnerabilities and exposures</cite></a>. ITU-T SG17.  International Telecommunication Union. Jan 2014. URL: <a href="https://www.itu.int/rec/T-REC-X.1520">https://www.itu.int/rec/T-REC-X.1520</a></dd><dt id="bib-itux1524">[ITUx1524]</dt><dd><a href="https://www.itu.int/rec/T-REC-X.1524"><cite>ITU-T Rec. X.1524 Common weakness enumeration</cite></a>. ITU-T SG17.  International Telecommunication Union. March 2012. URL: <a href="https://www.itu.int/rec/T-REC-X.1524">https://www.itu.int/rec/T-REC-X.1524</a></dd><dt id="bib-jon14">[Jon14]</dt><dd><a href="http://www.niso.org/sites/default/files/stories/2017-08/SP_Jones_JSON_isqv26no3.pdf"><cite>A JSON-Based Identity Protocol Suite</cite></a>. M. Jones.  Information Standards Quarterly, vol. 26, no. 3. 2014. URL: <a href="http://www.niso.org/sites/default/files/stories/2017-08/SP_Jones_JSON_isqv26no3.pdf">http://www.niso.org/sites/default/files/stories/2017-08/SP_Jones_JSON_isqv26no3.pdf</a></dd><dt id="bib-jwe15">[JWE15]</dt><dd><a href="https://tools.ietf.org/html/rfc7516"><cite>JSON Web Encryption (JWE)</cite></a>.  IETF. May 2015. URL: <a href="https://tools.ietf.org/html/rfc7516">https://tools.ietf.org/html/rfc7516</a></dd><dt id="bib-jws15">[JWS15]</dt><dd><a href="https://tools.ietf.org/html/rfc7515"><cite>JSON Web Signature (JWS)</cite></a>.  IETF. May 2015. URL: <a href="https://tools.ietf.org/html/rfc7515">https://tools.ietf.org/html/rfc7515</a></dd><dt id="bib-jwt15">[JWT15]</dt><dd><a href="https://tools.ietf.org/html/rfc7519"><cite>JSON Web Token (JWT)</cite></a>.  IETF. May 2015. URL: <a href="https://tools.ietf.org/html/rfc7519">https://tools.ietf.org/html/rfc7519</a></dd><dt id="bib-ken03">[Ken03]</dt><dd><a href="https://www.nap.edu/read/10656/chapter/1"><cite>Who Goes There? Authentication Through the Lens of Privacy</cite></a>. S. Kent; L. Millet.  The National Academies Press, Washington D.C. 2003. URL: <a href="https://www.nap.edu/read/10656/chapter/1">https://www.nap.edu/read/10656/chapter/1</a></dd><dt id="bib-klocwork">[Klocwork]</dt><dd><a href="https://www.roguewave.com/products-services/klocwork"><cite>Klocwork. Faster delivery of secure, reliable, and conformant code</cite></a>. URL: <a href="https://www.roguewave.com/products-services/klocwork">https://www.roguewave.com/products-services/klocwork</a></dd><dt id="bib-lam04">[Lam04]</dt><dd><a href="https://pdfs.semanticscholar.org/6fe5/ba7a096e391d985e7818fef9d0f0636210a0.pdf"><cite>Computer Security in the Real World</cite></a>. B. Lampson.  IEEE Computer, vol. 37, no. 6. June 2004. URL: <a href="https://pdfs.semanticscholar.org/6fe5/ba7a096e391d985e7818fef9d0f0636210a0.pdf">https://pdfs.semanticscholar.org/6fe5/ba7a096e391d985e7818fef9d0f0636210a0.pdf</a></dd><dt id="bib-lea05">[Lea05]</dt><dd><a href="https://tools.ietf.org/html/rfc4122"><cite>A Universally Unique IDentifier (UUID) URN Namespace</cite></a>. P. Leach; et al.  IETF RFC 4122. July 2005. URL: <a href="https://tools.ietf.org/html/rfc4122">https://tools.ietf.org/html/rfc4122</a></dd><dt id="bib-loc05">[Loc05]</dt><dd><a href="http://www.oracle.com/technetwork/testcontent/saml-084342.html"><cite>Demystifying SAML</cite></a>. H. Lockhart. May 2005. URL: <a href="http://www.oracle.com/technetwork/testcontent/saml-084342.html">http://www.oracle.com/technetwork/testcontent/saml-084342.html</a></dd><dt id="bib-mel15">[Mel15]</dt><dd><a href="https://c.ymcdn.com/sites/www.issa.org/resource/resmgr/journalpdfs/feature0615.pdf"><cite>Securing the Industrial Internet of Things</cite></a>. D. Melzer. June 2015. URL: <a href="https://c.ymcdn.com/sites/www.issa.org/resource/resmgr/journalpdfs/feature0615.pdf">https://c.ymcdn.com/sites/www.issa.org/resource/resmgr/journalpdfs/feature0615.pdf</a></dd><dt id="bib-mic17">[Mic17]</dt><dd><a href="https://docs.microsoft.com/en-us/azure/iot-suite/iot-security-architecture"><cite>Internet of Things security architecture</cite></a>. Microsoft.  STRIDE threat model for IoT. Jan 2017. URL: <a href="https://docs.microsoft.com/en-us/azure/iot-suite/iot-security-architecture">https://docs.microsoft.com/en-us/azure/iot-suite/iot-security-architecture</a></dd><dt id="bib-moo02">[Moo02]</dt><dd><a href="https://www.csd.uoc.gr/~hy435/material/moors.pdf"><cite>A critical review of End-to-end arguments in system design</cite></a>. T. Moors.  Proc. of the IEEE International Conference on Communications. 2002. URL: <a href="https://www.csd.uoc.gr/~hy435/material/moors.pdf">https://www.csd.uoc.gr/~hy435/material/moors.pdf</a></dd><dt id="bib-nikto">[Nikto]</dt><dd><a href="https://cirt.net/Nikto2"><cite>Nikto web server scanner</cite></a>. URL: <a href="https://cirt.net/Nikto2">https://cirt.net/Nikto2</a></dd><dt id="bib-nis15">[Nis15]</dt><dd><cite>Guide to Industrial Control Systems (ICS) Security</cite>. NIST.  NIST Special Publication 800-82. </dd><dt id="bib-ocf17">[Ocf17]</dt><dd><a href="https://openconnectivity.org/specs/OCF_Security_Specification_v1.0.0.pdf"><cite>The OCF Security Specification, version 1.0.0</cite></a>.  OCF. June 2017. URL: <a href="https://openconnectivity.org/specs/OCF_Security_Specification_v1.0.0.pdf">https://openconnectivity.org/specs/OCF_Security_Specification_v1.0.0.pdf</a></dd><dt id="bib-oos10">[Oos10]</dt><dd><a href="https://tnc2011.terena.org/getfile/696"><cite>Provisioning scenarios in identity federations</cite></a>. M. Oosdijk; et al..  Surfnet Research Paper. 2010. URL: <a href="https://tnc2011.terena.org/getfile/696">https://tnc2011.terena.org/getfile/696</a></dd><dt id="bib-oscoap17">[OSCOAP17]</dt><dd><a href="https://tools.ietf.org/pdf/draft-ietf-core-object-security-04.pdf"><cite>Object Security of CoAP (OSCOAP)</cite></a>.  IETF. July 2017. Internet-Draft. URL: <a href="https://tools.ietf.org/pdf/draft-ietf-core-object-security-04.pdf">https://tools.ietf.org/pdf/draft-ietf-core-object-security-04.pdf</a></dd><dt id="bib-owa17">[Owa17]</dt><dd><a href="https://www.owasp.org/index.php/Threat_Risk_Modeling"><cite>Threat Risk Modeling</cite></a>. OWASP.  OWASP. Jan 2017. URL: <a href="https://www.owasp.org/index.php/Threat_Risk_Modeling">https://www.owasp.org/index.php/Threat_Risk_Modeling</a></dd><dt id="bib-owa18">[Owa18]</dt><dd><a href="https://www.owasp.org/index.php/Web_Service_Security_Testing_Cheat_Sheet"><cite>Web Service Security Testing</cite></a>. OWASP.  OWASP. Aug 2018. URL: <a href="https://www.owasp.org/index.php/Web_Service_Security_Testing_Cheat_Sheet">https://www.owasp.org/index.php/Web_Service_Security_Testing_Cheat_Sheet</a></dd><dt id="bib-owasp-dependency-check">[OWASP-Dependency-Check]</dt><dd><a href="https://www.owasp.org/index.php/OWASP_Dependency_Check"><cite>OWASP Dependency Check</cite></a>. URL: <a href="https://www.owasp.org/index.php/OWASP_Dependency_Check">https://www.owasp.org/index.php/OWASP_Dependency_Check</a></dd><dt id="bib-peachpit-coap">[PeachPit-COAP]</dt><dd><a href="https://www.peach.tech/wp-content/uploads/CoAP_DataSheet.pdf"><cite>CoAP Peach Pit User Guide</cite></a>. URL: <a href="https://www.peach.tech/wp-content/uploads/CoAP_DataSheet.pdf">https://www.peach.tech/wp-content/uploads/CoAP_DataSheet.pdf</a></dd><dt id="bib-pri19">[Pri19]</dt><dd><a href="https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-26"><cite>Bootstrapping Remote Secure Key Infrastructures (BRSKI)</cite></a>. M. Pritikin, M. Richardson, T. Eckert,M. Behringer, K. Watsen.  IETF. Aug. 2019. URL: <a href="https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-26">https://tools.ietf.org/html/draft-ietf-anima-bootstrapping-keyinfra-26</a></dd><dt id="bib-protecode">[Protecode]</dt><dd><a href="https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html"><cite>Black Duck Software Composition Analysis</cite></a>. URL: <a href="https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html">https://www.synopsys.com/software-integrity/security-testing/software-composition-analysis.html</a></dd><dt id="bib-res03">[Res03]</dt><dd><a href="https://tools.ietf.org/html/rfc3552"><cite>Guidelines for Writing RFC Text on Security Considerations</cite></a>. E. Rescorla; et al..  IETF RFC 3552 (IAB Guideline). 2003. URL: <a href="https://tools.ietf.org/html/rfc3552">https://tools.ietf.org/html/rfc3552</a></dd><dt id="bib-sch14">[Sch14]</dt><dd><a href="https://www.wired.com/2014/01/theres-no-good-way-to-patch-the-internet-of-things-and-thats-a-huge-problem/"><cite>The Internet of Things Is Wildly Insecure — And Often Unpatchable</cite></a>. B. Schneier.  Wired. Jan. 2014. URL: <a href="https://www.wired.com/2014/01/theres-no-good-way-to-patch-the-internet-of-things-and-thats-a-huge-problem/">https://www.wired.com/2014/01/theres-no-good-way-to-patch-the-internet-of-things-and-thats-a-huge-problem/</a></dd><dt id="bib-sch99">[Sch99]</dt><dd><a href="https://www.schneier.com/paper-smart-card-threats.pdf"><cite>Breaking Up Is Hard To Do: Modeling Security Threats for Smart Cards</cite></a>. B. Scheier; A. Shostack.  USENIX Workshop on Smart Card Technology, USENIX Press. 1999. URL: <a href="https://www.schneier.com/paper-smart-card-threats.pdf">https://www.schneier.com/paper-smart-card-threats.pdf</a></dd><dt id="bib-sdo">[SDO]</dt><dd><a href="https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/intel-secure-device-onboard-product-brief.pdf"><cite>Intel® Secure Device Onboard</cite></a>.  Intel. 2017. URL: <a href="https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/intel-secure-device-onboard-product-brief.pdf">https://www.intel.com/content/dam/www/public/us/en/documents/product-briefs/intel-secure-device-onboard-product-brief.pdf</a></dd><dt id="bib-she14">[She14]</dt><dd><a href="https://tools.ietf.org/rfc/rfc7252.txt"><cite>The Constrained Application Protocol (CoAP)</cite></a>. Z. Shelby; et al..  IETF RFC 7252. June 2014. URL: <a href="https://tools.ietf.org/rfc/rfc7252.txt">https://tools.ietf.org/rfc/rfc7252.txt</a></dd><dt id="bib-snyk">[Snyk]</dt><dd><a href="https://snyk.io/"><cite>A developer-first solution that automates finding and fixing vulnerabilities in your dependencies</cite></a>. URL: <a href="https://snyk.io/">https://snyk.io/</a></dd><dt id="bib-tcpdump">[tcpdump]</dt><dd><a href="https://www.tcpdump.org/"><cite>tcpdump and libpcap project page</cite></a>. URL: <a href="https://www.tcpdump.org/">https://www.tcpdump.org/</a></dd><dt id="bib-vol00">[Vol00]</dt><dd><a href="https://tools.ietf.org/rfc/rfc2904.txt"><cite>AAA Authorization Framework</cite></a>. J. Vollbrecht; et al..  IETF RFC 2904. Aug. 2000. URL: <a href="https://tools.ietf.org/rfc/rfc2904.txt">https://tools.ietf.org/rfc/rfc2904.txt</a></dd><dt id="bib-w3af">[w3af]</dt><dd><a href="http://w3af.org/"><cite>Web Application Attack and Audit Framework</cite></a>. URL: <a href="http://w3af.org/">http://w3af.org/</a></dd><dt id="bib-wapiti">[wapiti]</dt><dd><a href="http://wapiti.sourceforge.net/"><cite>Wapiti - The web-application vulnerability scanner</cite></a>. URL: <a href="http://wapiti.sourceforge.net/">http://wapiti.sourceforge.net/</a></dd><dt id="bib-watobo">[WATOBO]</dt><dd><a href="http://watobo.sourceforge.net/index.html"><cite>WATOBO. The Web Application Toolbox</cite></a>. URL: <a href="http://watobo.sourceforge.net/index.html">http://watobo.sourceforge.net/index.html</a></dd><dt id="bib-wfuzz">[Wfuzz]</dt><dd><a href="http://www.edge-security.com/wfuzz.php"><cite>Wfuzz. The web application Bruteforcer</cite></a>. URL: <a href="http://www.edge-security.com/wfuzz.php">http://www.edge-security.com/wfuzz.php</a></dd><dt id="bib-wireshark">[Wireshark]</dt><dd><a href="https://www.wireshark.org/"><cite>Wireshark project page</cite></a>. URL: <a href="https://www.wireshark.org/">https://www.wireshark.org/</a></dd><dt id="bib-wot-architecture">[WoT-Architecture]</dt><dd><a href="https://www.w3.org/TR/wot-architecture/"><cite>Web of Things (WoT) Architecture</cite></a>. Matthias Kovatsch; Ryuichi Matsukura; Michael Lagally; Toru Kawaguchi; Kunihiko Toumura; Kazuo Kajimoto.  W3C. 9 April 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/wot-architecture/">https://www.w3.org/TR/wot-architecture/</a></dd><dt id="bib-wot-binding-templates">[WoT-Binding-Templates]</dt><dd><a href="https://www.w3.org/TR/wot-binding-templates/"><cite>Web of Things (WoT) Binding Templates</cite></a>. Michael Koster; Ege Korkan.  W3C. 30 January 2020. W3C Note. URL: <a href="https://www.w3.org/TR/wot-binding-templates/">https://www.w3.org/TR/wot-binding-templates/</a></dd><dt id="bib-wot-scripting-api">[WoT-Scripting-API]</dt><dd><a href="https://www.w3.org/TR/wot-scripting-api/"><cite>Web of Things (WoT) Scripting API</cite></a>. Zoltan Kis; Daniel Peintner; Cristiano Aguzzi; Johannes Hund; Kazuaki Nimura.  W3C. 24 November 2020. W3C Note. URL: <a href="https://www.w3.org/TR/wot-scripting-api/">https://www.w3.org/TR/wot-scripting-api/</a></dd><dt id="bib-wot-thing-description">[WoT-Thing-Description]</dt><dd><a href="https://www.w3.org/TR/wot-thing-description/"><cite>Web of Things (WoT) Thing Description</cite></a>. Sebastian Käbisch; Takuki Kamiya; Michael McCool; Victor Charpenay; Matthias Kovatsch.  W3C. 9 April 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/wot-thing-description/">https://www.w3.org/TR/wot-thing-description/</a></dd><dt id="bib-yeg11">[Yeg11]</dt><dd><a href="https://plus.google.com/+RipRowan/posts/eVeouesvaVX"><cite>Stevey's Google Platforms Rant</cite></a>. S. Yegge.  Blog. Oct. 2011. URL: <a href="https://plus.google.com/+RipRowan/posts/eVeouesvaVX">https://plus.google.com/+RipRowan/posts/eVeouesvaVX</a></dd>
+    </dl></section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><script src="https://www.w3.org/scripts/TR/2016/fixup.js"></script></body></html>


### PR DESCRIPTION
- Added explicit "id" to all dfn tags
- However, not really sure we need them, since
     - When "static" version is exported ReSpec does generate them all
     - Links do work even in ReSpec version if you can figure out the id, which is generated deterministically from defined term
     - Can also get link by clicking on entry and selecting "Permalink"

In summary, even though I made this PR, I don't think we need to merge it.  We can keep it for information and discussion but I propose closing without merging.