### PR TITLE
Migrate to new ReSpec profile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="tablestyle.css">
     <meta charset="utf-8" />
     <title>Web of Things (WoT) Security and Privacy Guidelines</title>
-    <script class="remove" async="" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" async="" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <script class="remove">
           var respecConfig = {
               specStatus:     "ED"
@@ -12,6 +12,7 @@
             , processVersion: 2017
             , shortName:      "wot-security"
             , copyrightStart: 2017
+            , group:          "wg/wot"
             , wg:             "Web of Things Working Group"
             , wgURI:          "https://www.w3.org/WoT/WG/"
             , wgPublicList:   "public-wot-wg"

--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
             , shortName:      "wot-security"
             , copyrightStart: 2017
             , group:          "wg/wot"
+            , lint: {
+                "no-unused-dfns": false
+            }
             , wg:             "Web of Things Working Group"
             , wgURI:          "https://www.w3.org/WoT/WG/"
             , wgPublicList:   "public-wot-wg"


### PR DESCRIPTION
- migrate from respec-w3c-common to respec-w3c
- add "group" definition as "wg/wot"
- Note: gets rid of single warning about use of respec-w3-common, but adds 10 new warnings about definitions that are not used.  This is ok as they may be used in *other* documents, and we can suppress warnings with an option to respecConfig:
```json
{ "lint": { "no-unused-dfns": false  } }
```
- The above option was added to suppress the warnings.  Note: quotes around "lint" not used but required for "no-unused-dfns" because of - in name.  Sigh... technically all keys should be quoted for JSON.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-security/pull/226.html" title="Last updated on Aug 8, 2023, 4:04 PM UTC (d4aedf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security/226/b5c0c4a...mmccool:d4aedf1.html" title="Last updated on Aug 8, 2023, 4:04 PM UTC (d4aedf1)">Diff</a>