### PR TITLE
Remove rawgit links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ and is used to manage cross-cutting security and privacy considerations.
       This compiles out the complex JavaScript implementing the ReSpec system,
       making it faster to view and more compatible with a wider range of browsers.
       However, there may a small delay before it gets updated when the master changes.
-    * A working "unstable" version is also available [here](https://rawgit.com/w3c/wot-security/working/index.html)
-      but has not yet been validated and may have errors.
-      It is also not "compiled" and so may be slow to display (or display with issues) on some broswers.
 * You may also be interested in the 
   [WoT Security Best Practices document](https://github.com/w3c/wot-security-best-practices).
   The Guidelines describe general principles and establish foundational definitions.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ and is used to manage cross-cutting security and privacy considerations.
 * [WoT Security and Privacy Guidelines](index.html):
   A unified set of informative recommendations for security and privacy in a Web of Things system.
   Includes a threat model.  
-    * The latest stable version can be found [here](https://rawgit.com/w3c/wot-security/master/index.html).
+    * The latest stable version can be found [here](https://github.com/w3c/wot-security/blob/main/index.html).
     * A "rendered" form of the latest stable version can be found [here](https://w3c.github.io/wot-security/).
       This compiles out the complex JavaScript implementing the ReSpec system,
       making it faster to view and more compatible with a wider range of browsers.


### PR DESCRIPTION
This PR fixes #200, an issue opened a while ago by @Citrullin, by removing the "rawgit" links from the README as well as a dead reference to the working branch (which has been merged and deleted a while ago in #179).